### PR TITLE
chore(ci): CI matrix + GoReleaser + Homebrew tap + main stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Format check
+        if: matrix.os != 'windows-2022'
+        shell: bash
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "gofmt would reformat:"; echo "$unformatted"; exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Tidy check
+        if: matrix.os != 'windows-2022'
+        shell: bash
+        run: |
+          go mod tidy
+          dirty=$(git status --porcelain -- go.mod go.sum)
+          if [ -n "$dirty" ]; then
+            echo "go mod tidy produced changes — commit them:"
+            echo "$dirty"
+            git diff -- go.mod go.sum || true
+            exit 1
+          fi
+
+      - name: Build (native)
+        run: go build ./...
+
+      - name: Cross-compile sanity (darwin+windows+linux)
+        if: matrix.os == 'ubuntu-24.04'
+        shell: bash
+        run: |
+          for tgt in "darwin arm64" "darwin amd64" "windows amd64" "windows arm64" "linux amd64" "linux arm64"; do
+            set -- $tgt
+            GOOS=$1 GOARCH=$2 go build ./... || { echo "cross-build failed: $tgt"; exit 1; }
+          done
+
+      - name: Test
+        run: go test ./... -race -count=1 -timeout=5m
+
+      # (deliberate: no test-artifact upload on failure — CI logs are sufficient)
+
+  lint:
+    name: lint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.62
+          args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - revive
+    - misspell
+    - unconvert
+    - bodyclose
+
+linters-settings:
+  revive:
+    rules:
+      - name: var-naming
+      - name: exported
+        arguments: [checkPrivateReceivers, sayRepetitiveInsteadOfStutters]
+  misspell:
+    locale: US
+
+issues:
+  exclude-dirs:
+    - internal/schema/extract  # maintainer tool, looser rules
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - revive
+    - path: cmd/cowork-mdm/main\.go
+      linters:
+        - revive  # main is a sink

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,86 @@
+version: 2
+
+project_name: cowork-mdm
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: cowork-mdm
+    main: ./cmd/cowork-mdm
+    binary: cowork-mdm
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.CommitDate}}
+    goos: [darwin, linux, windows]
+    goarch: [amd64, arm64]
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}arm64
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+      - "^ci:"
+      - "Merge pull request"
+      - "Merge branch"
+
+release:
+  draft: false
+  prerelease: auto
+  github:
+    owner: krislavten
+    name: cowork-mdm
+  footer: |
+    ---
+
+    **Not affiliated with Anthropic.** This project is an independent tool built on
+    public reverse-engineering of the Claude Desktop application.
+
+brews:
+  - name: cowork-mdm
+    repository:
+      owner: krislavten
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/krislavten/cowork-mdm
+    description: |
+      Claude Desktop enterprise deployment toolkit — MDM config profiles,
+      plugin marketplace management, and per-host diagnostics.
+    license: MIT
+    test: |
+      system "#{bin}/cowork-mdm --version"
+    install: |
+      bin.install "cowork-mdm"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ cowork-mdm doctor --fix                     # auto-repair what's auto-repairable
 
 See [AGENTS.md](AGENTS.md) for development conventions. Issues and PRs welcome.
 
+## Maintainer notes
+
+### Releasing
+
+Releases are tag-triggered. Push a `v*` tag and `.github/workflows/release.yml` runs GoReleaser.
+
+The release job publishes to two places:
+1. **GitHub Releases** on this repo — uses the default `GITHUB_TOKEN`.
+2. **Homebrew tap** at `krislavten/homebrew-tap` — requires secret `HOMEBREW_TAP_GITHUB_TOKEN` on this repo. The token must be a personal access token (classic or fine-grained) with **contents:write** on `krislavten/homebrew-tap`. Without it, the brew formula push step fails; everything else (GitHub Release + binaries + checksums) still succeeds.
+
+Set the secret once:
+```bash
+gh secret set HOMEBREW_TAP_GITHUB_TOKEN --repo krislavten/cowork-mdm
+# paste the PAT when prompted
+```
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/cmd/cowork-mdm/main.go
+++ b/cmd/cowork-mdm/main.go
@@ -1,0 +1,20 @@
+// Command cowork-mdm is a CLI toolkit for deploying Claude Desktop in the enterprise.
+//
+// This is a pre-release stub; the command surface lands in milestone M3 (see
+// docs/execution/TASKS.md). The stub exists so that `go build ./...` and the
+// release pipeline have a compilable entry point from day 1.
+package main
+
+import "fmt"
+
+// These are populated at build time via -ldflags by GoReleaser.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	fmt.Printf("cowork-mdm %s (commit %s, built %s)\n", version, commit, date)
+	fmt.Println("(pre-release — full command surface arrives in v0.2 milestone M3)")
+}


### PR DESCRIPTION
## Summary

Sets up the release pipeline before the swarm starts — so agents can rely on CI gating from their first PR.

- CI: gofmt / vet / tidy / build (all platforms × amd64+arm64 cross-compile) / race test
- golangci-lint v1.62 with errcheck/staticcheck/revive/bodyclose
- GoReleaser v2 publishing to GitHub Releases + Homebrew tap (krislavten/homebrew-tap)
- Minimal main.go so go build ./... passes from commit one

## Sparring trail

Codex rescue APPROVE after 2 SHOULD-FIX fixed:
- tidy check now uses git status --porcelain (catches untracked go.sum).
- upload-artifact step removed (was using un-expanded env var in path).

## Post-merge steps

Before first v0.2.0 tag, the maintainer must set HOMEBREW_TAP_GITHUB_TOKEN on this repo (see README). Without it the brew formula push in release.yml will fail but binaries will still publish.

## Test plan

- [x] Local gofmt, vet, build pass.
- [x] goreleaser schema v2 syntax spot-checked.
- [ ] CI first run on this PR shows all jobs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)