### PR TITLE
task-01: add internal/schema

### DIFF
--- a/docs/execution/progress/schema-agent.md
+++ b/docs/execution/progress/schema-agent.md
@@ -1,0 +1,16 @@
+# schema-agent progress
+
+## 2026-04-30T15:05:09Z — Started task-01
+
+Claimed task-01 (internal/schema/). Worktree: /tmp/agent-wt/schema, branch feat/task-01.
+
+Plan:
+1. Write `internal/schema/schema.go` with embedded schema.json, Load/Find/Validate per spec.
+2. Write `schema_test.go` and `validate_test.go`.
+3. Write `internal/schema/extract/extract.go` with //go:build extract and a smoke test fixture.
+4. Run the 5-step gate, Sparring review via /codex:rescue.
+
+Key observations:
+- schema.json already contains 51 keys with all 7 types represented.
+- schema.json has an extra `default` field not in the Key struct spec; json.Unmarshal will ignore it (fine).
+- Spec defines `ExtractedFromApp` on Key but notes it's populated from parent JSON (json:"-"). Since schema.json doesn't carry per-key `extractedFromApp`, we'll populate it from Schema.ExtractedFromAppVersion in Load().

--- a/internal/schema/extract/extract.go
+++ b/internal/schema/extract/extract.go
@@ -1,0 +1,837 @@
+//go:build extract
+
+// Command extract regenerates internal/schema/schema.json from a
+// Claude Desktop release. Guarded by the `extract` build tag so it's
+// never linked into the production binary.
+//
+// Typical usage:
+//
+//	go run -tags extract ./internal/schema/extract \
+//	    --from /Applications/Claude.app \
+//	    --out  internal/schema/schema.json
+//
+// The tool:
+//  1. Extracts the app.asar (shells out to `npx @electron/asar extract`
+//     unless --asar-tool is overridden).
+//  2. Locates `.vite/build/index.js` inside the extracted tree.
+//  3. Finds the minified schema literal of the form `FJ=me({...})` and
+//     brace-matches the outer `()`.
+//  4. Parses the block into a []Key list using regex scanners.
+//  5. Emits a pretty-printed JSON document.
+//
+// The extractor is fragile by design — it's a one-time-per-release
+// maintenance task, not runtime logic. Produced output only needs to
+// be "a reasonable schema"; downstream (schema.go + tests) checks
+// shape and key count. Review the diff before committing.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Type / Scope names must track internal/schema/schema.go. Re-declared
+// here as plain strings so the extractor stays a self-contained main
+// and doesn't import the schema package (the schema package embeds
+// this tool's output — importing back would be a circular mess).
+const (
+	typeString      = "string"
+	typeBoolean     = "boolean"
+	typeInteger     = "integer"
+	typeStringArray = "stringArray"
+	typeJSONString  = "jsonString"
+	typeURL         = "url"
+	typeEnum        = "enum"
+)
+
+type extractedKey struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Scopes      []string `json:"scopes"`
+	AppMin      string   `json:"appMin,omitempty"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Example     any      `json:"example,omitempty"`
+	LegacyAlias string   `json:"legacyAlias,omitempty"`
+	Sensitive   bool     `json:"sensitive,omitempty"`
+	Provider    string   `json:"provider,omitempty"`
+	Category    string   `json:"category,omitempty"`
+	EnumValues  []string `json:"enumValues,omitempty"`
+}
+
+type extractedSchema struct {
+	Version                 string         `json:"version"`
+	ExtractedFromAppVersion string         `json:"extractedFromAppVersion"`
+	Keys                    []extractedKey `json:"keys"`
+}
+
+func main() {
+	var (
+		fromPath   = flag.String("from", "", "path to Claude.app (or any dir/file that resolves to app.asar)")
+		outPath    = flag.String("out", "-", "output file path, or '-' for stdout")
+		asarTool   = flag.String("asar-tool", "npx @electron/asar", "command used to unpack app.asar (--from override)")
+		appVersion = flag.String("app-version", "", "override the extractedFromAppVersion field (else read from Info.plist / package.json if possible)")
+		keepTmp    = flag.Bool("keep-tmp", false, "keep the extracted asar tmpdir for inspection")
+	)
+	flag.Parse()
+
+	if *fromPath == "" {
+		fmt.Fprintln(os.Stderr, "error: --from is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	schema, err := extractFromApp(*fromPath, *asarTool, *appVersion, *keepTmp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "extract failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeJSON(*outPath, schema); err != nil {
+		fmt.Fprintf(os.Stderr, "write failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func writeJSON(path string, s *extractedSchema) error {
+	buf, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	buf = append(buf, '\n')
+	if path == "-" {
+		_, err := os.Stdout.Write(buf)
+		return err
+	}
+	return os.WriteFile(path, buf, 0o644)
+}
+
+// extractFromApp is the top-level driver. It is separated from main()
+// so the smoke test can drive individual sub-steps.
+func extractFromApp(appPath, asarTool, appVersion string, keepTmp bool) (*extractedSchema, error) {
+	asarFile, err := locateAsar(appPath)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "cowork-mdm-extract-")
+	if err != nil {
+		return nil, fmt.Errorf("mkdir temp: %w", err)
+	}
+	if !keepTmp {
+		defer os.RemoveAll(tmpDir)
+	} else {
+		fmt.Fprintf(os.Stderr, "keeping extracted asar at %s\n", tmpDir)
+	}
+
+	if err := runAsarExtract(asarTool, asarFile, tmpDir); err != nil {
+		return nil, err
+	}
+
+	indexJS, err := os.ReadFile(filepath.Join(tmpDir, ".vite", "build", "index.js"))
+	if err != nil {
+		return nil, fmt.Errorf("read .vite/build/index.js: %w", err)
+	}
+
+	keys, err := parseSchemaLiteral(string(indexJS))
+	if err != nil {
+		return nil, err
+	}
+
+	if appVersion == "" {
+		appVersion = detectAppVersion(appPath, tmpDir)
+	}
+
+	return &extractedSchema{
+		Version:                 "1",
+		ExtractedFromAppVersion: appVersion,
+		Keys:                    keys,
+	}, nil
+}
+
+func locateAsar(appPath string) (string, error) {
+	info, err := os.Stat(appPath)
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", appPath, err)
+	}
+	if !info.IsDir() {
+		// Assume user passed the .asar directly.
+		return appPath, nil
+	}
+	// Try the macOS bundle layout first, then generic Electron layouts.
+	candidates := []string{
+		filepath.Join(appPath, "Contents", "Resources", "app.asar"),
+		filepath.Join(appPath, "resources", "app.asar"),
+		filepath.Join(appPath, "app.asar"),
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("could not find app.asar under %s (looked in %v)", appPath, candidates)
+}
+
+func runAsarExtract(toolCmd, asar, dst string) error {
+	parts := strings.Fields(toolCmd)
+	if len(parts) == 0 {
+		return errors.New("--asar-tool is empty")
+	}
+	args := append(parts[1:], "extract", asar, dst)
+	cmd := exec.Command(parts[0], args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s extract: %w", toolCmd, err)
+	}
+	return nil
+}
+
+func detectAppVersion(appPath, tmpDir string) string {
+	// package.json inside the asar is authoritative.
+	if data, err := os.ReadFile(filepath.Join(tmpDir, "package.json")); err == nil {
+		var pkg struct {
+			Version string `json:"version"`
+		}
+		if json.Unmarshal(data, &pkg) == nil && pkg.Version != "" {
+			return pkg.Version
+		}
+	}
+	// Fall back to macOS Info.plist CFBundleShortVersionString grep.
+	plist := filepath.Join(appPath, "Contents", "Info.plist")
+	if data, err := os.ReadFile(plist); err == nil {
+		re := regexp.MustCompile(`<key>CFBundleShortVersionString</key>\s*<string>([^<]+)</string>`)
+		if m := re.FindSubmatch(data); len(m) == 2 {
+			return string(m[1])
+		}
+	}
+	return "unknown"
+}
+
+// parseSchemaLiteral locates and decodes the `FJ=me({...})` block.
+// Exported for the smoke test.
+func parseSchemaLiteral(src string) ([]extractedKey, error) {
+	start, body, err := locateMeCall(src)
+	if err != nil {
+		return nil, err
+	}
+	_ = start
+
+	keys, err := parseKeyBlock(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse key block: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("schema literal yielded 0 keys — likely a parser mismatch")
+	}
+	sort.SliceStable(keys, func(i, j int) bool { return keys[i].Name < keys[j].Name })
+	return keys, nil
+}
+
+// locateMeCall finds `FJ=me({...})` and returns the argument substring
+// between the outer `{` and matching `}` (i.e. the key-set literal).
+func locateMeCall(src string) (int, string, error) {
+	// Tolerate whitespace between tokens: `FJ = me ({`.
+	re := regexp.MustCompile(`FJ\s*=\s*me\s*\(\s*\{`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return 0, "", errors.New("could not find `FJ=me({` in index.js")
+	}
+	// loc[1] points just past the '{'. Brace-match from there.
+	end, err := matchBrace(src, loc[1]-1)
+	if err != nil {
+		return 0, "", fmt.Errorf("brace-match from FJ=me({: %w", err)
+	}
+	return loc[0], src[loc[1]:end], nil
+}
+
+// matchBrace assumes src[open] == '{' and returns the index of its
+// matching '}'. String literals (single, double, backtick) are
+// skipped.
+func matchBrace(src string, open int) (int, error) {
+	if open >= len(src) || src[open] != '{' {
+		return 0, fmt.Errorf("matchBrace: src[%d] != '{'", open)
+	}
+	depth := 1
+	i := open + 1
+	for i < len(src) {
+		c := src[i]
+		switch c {
+		case '\\':
+			i += 2 // skip escape even outside strings — harmless
+			continue
+		case '\'', '"', '`':
+			j, err := skipString(src, i)
+			if err != nil {
+				return 0, err
+			}
+			i = j
+			continue
+		case '/':
+			// Skip // line comments and /* block comments — the JS
+			// bundle is minified but this is cheap safety.
+			if i+1 < len(src) && src[i+1] == '/' {
+				for i < len(src) && src[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			if i+1 < len(src) && src[i+1] == '*' {
+				end := strings.Index(src[i+2:], "*/")
+				if end < 0 {
+					return 0, errors.New("unterminated /* */ comment")
+				}
+				i = i + 2 + end + 2
+				continue
+			}
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, nil
+			}
+		}
+		i++
+	}
+	return 0, errors.New("unterminated { block")
+}
+
+// skipString advances past a string literal starting at src[i]. The
+// opening quote is src[i]; returns the index just past the closing
+// quote.
+func skipString(src string, i int) (int, error) {
+	quote := src[i]
+	j := i + 1
+	for j < len(src) {
+		c := src[j]
+		if c == '\\' {
+			j += 2
+			continue
+		}
+		if c == quote {
+			return j + 1, nil
+		}
+		// Backtick template literals may contain ${...} expressions;
+		// brace-match inside.
+		if quote == '`' && c == '$' && j+1 < len(src) && src[j+1] == '{' {
+			end, err := matchBrace(src, j+1)
+			if err != nil {
+				return 0, fmt.Errorf("template-literal ${...}: %w", err)
+			}
+			j = end + 1
+			continue
+		}
+		j++
+	}
+	return 0, fmt.Errorf("unterminated %c-quoted string", quote)
+}
+
+// parseKeyBlock walks the body of `FJ=me({ ... })`, locating each
+// top-level `<name>:<suffix?>(<typeExpr>,{...})` entry.
+//
+// The actual Claude bundle uses minifier-chosen suffixes like
+// `:nn(...)` or `:n5(...)`; we accept any short identifier between the
+// colon and the opening `(`.
+func parseKeyBlock(body string) ([]extractedKey, error) {
+	var keys []extractedKey
+	i := 0
+	for i < len(body) {
+		// Skip whitespace / commas between entries.
+		for i < len(body) && (body[i] == ' ' || body[i] == '\n' || body[i] == '\r' || body[i] == '\t' || body[i] == ',') {
+			i++
+		}
+		if i >= len(body) {
+			break
+		}
+
+		// Read identifier (possibly quoted).
+		name, next, ok := readPropertyName(body, i)
+		if !ok {
+			// Not at an entry start — skip this char and retry.
+			i++
+			continue
+		}
+		i = next
+
+		// Expect ':'.
+		i = skipSpaces(body, i)
+		if i >= len(body) || body[i] != ':' {
+			// Not a property; skip a char and keep scanning. (The me()
+			// block is flat, but forgiving here protects against the
+			// occasional comment or stray token.)
+			continue
+		}
+		i++
+
+		// Expect <suffix-ident>?  '('.
+		i = skipSpaces(body, i)
+		suffixStart := i
+		for i < len(body) && isIdent(body[i]) {
+			i++
+		}
+		_ = body[suffixStart:i] // suffix is ignored; kept for debugging
+		i = skipSpaces(body, i)
+
+		if i >= len(body) || body[i] != '(' {
+			continue
+		}
+		// Brace-match the call's ().
+		end, err := matchParen(body, i)
+		if err != nil {
+			return nil, fmt.Errorf("key %q: %w", name, err)
+		}
+		args := body[i+1 : end]
+		i = end + 1
+
+		key, err := parseKeyArgs(name, args)
+		if err != nil {
+			// Rather than fail the whole extraction, skip malformed
+			// entries with a stderr note. This makes the tool
+			// resilient to future Claude minification changes.
+			fmt.Fprintf(os.Stderr, "warn: key %q: %v\n", name, err)
+			continue
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func readPropertyName(src string, i int) (string, int, bool) {
+	if i >= len(src) {
+		return "", i, false
+	}
+	// Quoted property name.
+	if src[i] == '"' || src[i] == '\'' {
+		end, err := skipString(src, i)
+		if err != nil {
+			return "", i, false
+		}
+		// src[i+1:end-1] is the raw content.
+		return src[i+1 : end-1], end, true
+	}
+	if !isIdentStart(src[i]) {
+		return "", i, false
+	}
+	j := i
+	for j < len(src) && isIdent(src[j]) {
+		j++
+	}
+	return src[i:j], j, true
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '$'
+}
+
+func isIdent(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+func skipSpaces(src string, i int) int {
+	for i < len(src) && (src[i] == ' ' || src[i] == '\t' || src[i] == '\n' || src[i] == '\r') {
+		i++
+	}
+	return i
+}
+
+// matchParen behaves like matchBrace but for '(' / ')'.
+func matchParen(src string, open int) (int, error) {
+	if open >= len(src) || src[open] != '(' {
+		return 0, fmt.Errorf("matchParen: src[%d] != '('", open)
+	}
+	depth := 1
+	i := open + 1
+	for i < len(src) {
+		c := src[i]
+		switch c {
+		case '\\':
+			i += 2
+			continue
+		case '\'', '"', '`':
+			j, err := skipString(src, i)
+			if err != nil {
+				return 0, err
+			}
+			i = j
+			continue
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i, nil
+			}
+		case '{':
+			// Descend to keep string-in-object parsing consistent.
+			j, err := matchBrace(src, i)
+			if err != nil {
+				return 0, err
+			}
+			i = j + 1
+			continue
+		}
+		i++
+	}
+	return 0, errors.New("unterminated ( block")
+}
+
+// parseKeyArgs handles the `<typeExpr>, {<metadata>}` payload. The
+// metadata object carries title/description/scopes/etc.
+func parseKeyArgs(name, args string) (extractedKey, error) {
+	// Find the metadata object — the last '{' at the top level.
+	depth := 0
+	metaStart := -1
+	for i := 0; i < len(args); i++ {
+		c := args[i]
+		switch c {
+		case '\\':
+			i++
+			continue
+		case '\'', '"', '`':
+			j, err := skipString(args, i)
+			if err != nil {
+				return extractedKey{}, err
+			}
+			i = j - 1
+			continue
+		case '(', '[':
+			depth++
+		case ')', ']':
+			depth--
+		case '{':
+			if depth == 0 {
+				metaStart = i
+			} else {
+				depth++
+			}
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+
+	var typeExpr, metaBody string
+	if metaStart >= 0 {
+		typeExpr = strings.TrimSpace(trimTrailingComma(args[:metaStart]))
+		metaEnd, err := matchBrace(args, metaStart)
+		if err != nil {
+			return extractedKey{}, fmt.Errorf("metadata brace: %w", err)
+		}
+		metaBody = args[metaStart+1 : metaEnd]
+	} else {
+		typeExpr = strings.TrimSpace(args)
+	}
+
+	k := extractedKey{Name: name}
+	t, enumVals, err := classifyType(typeExpr)
+	if err != nil {
+		return extractedKey{}, fmt.Errorf("classify type %q: %w", typeExpr, err)
+	}
+	k.Type = t
+	k.EnumValues = enumVals
+
+	if metaBody != "" {
+		parseMetadata(&k, metaBody)
+	}
+	return k, nil
+}
+
+func trimTrailingComma(s string) string {
+	s = strings.TrimRight(s, " \t\n\r")
+	s = strings.TrimRight(s, ",")
+	return strings.TrimRight(s, " \t\n\r")
+}
+
+// classifyType maps Claude's schema-builder expressions to our Type
+// constants. This is the spec's "extraction algorithm step 5" mapping.
+func classifyType(expr string) (string, []string, error) {
+	e := strings.TrimSpace(expr)
+
+	// Enum: Ds([...])
+	if strings.HasPrefix(e, "Ds(") {
+		open := strings.Index(e, "[")
+		if open < 0 {
+			return "", nil, errors.New("Ds(...) without [ literal")
+		}
+		close := findMatching(e, open, '[', ']')
+		if close < 0 {
+			return "", nil, errors.New("unterminated [ in Ds")
+		}
+		vals := parseStringLiteralArray(e[open+1 : close])
+		return typeEnum, vals, nil
+	}
+
+	// Li(...) → stringArray (the element expression is conventionally MA()).
+	if strings.HasPrefix(e, "Li(") {
+		return typeStringArray, nil, nil
+	}
+
+	// Bare identifiers (possibly with trailing `.something()`).
+	head := leadingIdent(e)
+	switch head {
+	case "Hi":
+		return typeBoolean, nil, nil
+	case "MA":
+		return typeString, nil, nil
+	case "YsA", "r_":
+		return typeURL, nil, nil
+	case "ASt", "Vee":
+		return typeJSONString, nil, nil
+	case "PsA":
+		// PsA.number().int() — integer. PsA.string() shouldn't
+		// appear in practice; default to string if so.
+		if strings.Contains(e, ".number(") {
+			return typeInteger, nil, nil
+		}
+		return typeString, nil, nil
+	}
+	return "", nil, fmt.Errorf("unrecognized type expression %q", e)
+}
+
+func leadingIdent(s string) string {
+	i := 0
+	for i < len(s) && isIdent(s[i]) {
+		i++
+	}
+	return s[:i]
+}
+
+func findMatching(s string, open int, openCh, closeCh byte) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++
+			continue
+		case '\'', '"', '`':
+			j, err := skipString(s, i)
+			if err != nil {
+				return -1
+			}
+			i = j - 1
+			continue
+		}
+		if s[i] == openCh {
+			depth++
+		} else if s[i] == closeCh {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// parseStringLiteralArray returns the string values from `"a","b",'c'`.
+func parseStringLiteralArray(body string) []string {
+	var out []string
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		if c == '"' || c == '\'' || c == '`' {
+			end, err := skipString(body, i)
+			if err != nil {
+				return out
+			}
+			raw := body[i+1 : end-1]
+			out = append(out, unquoteJSString(raw))
+			i = end
+			continue
+		}
+		i++
+	}
+	return out
+}
+
+// parseMetadata populates the {scopes,title,description,...} block.
+// Minified JS sometimes uses unquoted keys; we scan by top-level
+// identifiers.
+func parseMetadata(k *extractedKey, body string) {
+	entries := splitTopLevelEntries(body)
+	for _, e := range entries {
+		colon := indexColonTopLevel(e)
+		if colon < 0 {
+			continue
+		}
+		rawKey := strings.TrimSpace(e[:colon])
+		rawVal := strings.TrimSpace(e[colon+1:])
+		// Key may be quoted.
+		if len(rawKey) >= 2 && (rawKey[0] == '"' || rawKey[0] == '\'') {
+			rawKey = rawKey[1 : len(rawKey)-1]
+		}
+
+		switch rawKey {
+		case "title":
+			k.Title = stringValue(rawVal)
+		case "description":
+			k.Description = stringValue(rawVal)
+		case "appMin":
+			k.AppMin = stringValue(rawVal)
+		case "legacyAlias":
+			k.LegacyAlias = stringValue(rawVal)
+		case "sensitive":
+			k.Sensitive = boolValue(rawVal)
+		case "provider":
+			k.Provider = stringValue(rawVal)
+		case "category":
+			k.Category = stringValue(rawVal)
+		case "example":
+			k.Example = stringValue(rawVal)
+		case "scopes":
+			k.Scopes = parseStringLiteralArray(trimArrayBrackets(rawVal))
+		}
+	}
+}
+
+func splitTopLevelEntries(body string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		switch c {
+		case '\\':
+			i++
+			continue
+		case '\'', '"', '`':
+			j, err := skipString(body, i)
+			if err != nil {
+				return out
+			}
+			i = j - 1
+			continue
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, body[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		out = append(out, body[start:])
+	}
+	return out
+}
+
+func indexColonTopLevel(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\\':
+			i++
+			continue
+		case '\'', '"', '`':
+			j, err := skipString(s, i)
+			if err != nil {
+				return -1
+			}
+			i = j - 1
+			continue
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ':':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func stringValue(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if len(raw) < 2 {
+		return ""
+	}
+	q := raw[0]
+	if q != '"' && q != '\'' && q != '`' {
+		return ""
+	}
+	// The value might be a concat: "foo " + "bar". Handle the common
+	// case by finding the first string token only — good enough for
+	// the minified code which rarely concatenates here.
+	end, err := skipString(raw, 0)
+	if err != nil {
+		return ""
+	}
+	return unquoteJSString(raw[1 : end-1])
+}
+
+func boolValue(raw string) bool {
+	return strings.TrimSpace(raw) == "true" || strings.TrimSpace(raw) == "!0"
+}
+
+func trimArrayBrackets(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// unquoteJSString decodes the most common JS escape sequences inside a
+// string literal body (without its delimiter quotes). It is NOT a
+// complete JS tokenizer — it handles \n \t \r \\ \" \' \` \uXXXX and
+// leaves unknown escapes alone. Template-literal ${...} expressions
+// are preserved as-is.
+func unquoteJSString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c != '\\' || i+1 >= len(s) {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		nxt := s[i+1]
+		switch nxt {
+		case 'n':
+			b.WriteByte('\n')
+			i += 2
+		case 't':
+			b.WriteByte('\t')
+			i += 2
+		case 'r':
+			b.WriteByte('\r')
+			i += 2
+		case '\\', '"', '\'', '`', '/':
+			b.WriteByte(nxt)
+			i += 2
+		case 'u':
+			if i+6 <= len(s) {
+				if n, err := strconv.ParseUint(s[i+2:i+6], 16, 32); err == nil {
+					b.WriteRune(rune(n))
+					i += 6
+					continue
+				}
+			}
+			b.WriteByte(c)
+			i++
+		default:
+			b.WriteByte(nxt)
+			i += 2
+		}
+	}
+	return b.String()
+}

--- a/internal/schema/extract/extract_test.go
+++ b/internal/schema/extract/extract_test.go
@@ -1,0 +1,175 @@
+//go:build extract
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeIndexJS mimics the shape of the minified Claude bundle well
+// enough for the parser to exercise every type branch. This is NOT a
+// real asar extraction — the smoke test only covers the parser.
+const fakeIndexJS = `
+// preamble — some other code lives here.
+var x = 1;
+FJ = me({
+  isDesktopExtensionEnabled: nn(Hi(), {
+    scopes: ["3p", "1p"],
+    title: "Allow desktop extensions",
+    description: "Permit users to install local desktop extensions.",
+    appMin: "0.14.1",
+    legacyAlias: "isDxtEnabled"
+  }),
+  inferenceProvider: n5(Ds(["bedrock","vertex","gateway","foundry"]), {
+    scopes: ["3p", "3p-bootstrap"],
+    appMin: "1.2.0",
+    title: "Inference provider",
+    description: "Selects the inference backend."
+  }),
+  coworkEgressAllowedHosts: k9(Li(MA()), {
+    scopes: ["3p"],
+    appMin: "1.3.0",
+    title: "Allowed egress hosts",
+    description: "Additional hostnames.",
+    example: "[\"docs.example.com\"]"
+  }),
+  managedMcpServers: k3(ASt, {
+    scopes: ["3p"],
+    appMin: "1.2.0",
+    title: "Managed MCP servers",
+    description: "JSON array of MCP server configs.",
+    sensitive: true,
+    example: "[{\"name\":\"x\"}]"
+  }),
+  otlpEndpoint: k4(YsA, {
+    scopes: ["3p", "3p-bootstrap"],
+    appMin: "1.4.0",
+    title: "OpenTelemetry collector endpoint",
+    description: "Base URL of an OpenTelemetry collector."
+  }),
+  autoUpdaterEnforcementHours: kk(PsA.number().int(), {
+    scopes: ["3p", "1p"],
+    appMin: "0.14.1",
+    title: "Auto-update enforcement window",
+    description: "Hours before forced install."
+  }),
+  otlpHeaders: kz(MA(), {
+    scopes: ["3p", "3p-bootstrap"],
+    appMin: "1.4.0",
+    title: "OpenTelemetry exporter headers",
+    description: "Headers sent with every OTLP request.",
+    sensitive: true
+  })
+});
+var y = 2;
+`
+
+func TestParseSchemaLiteral(t *testing.T) {
+	keys, err := parseSchemaLiteral(fakeIndexJS)
+	if err != nil {
+		t.Fatalf("parseSchemaLiteral: %v", err)
+	}
+	byName := map[string]extractedKey{}
+	for _, k := range keys {
+		byName[k.Name] = k
+	}
+
+	want := map[string]string{
+		"isDesktopExtensionEnabled":   typeBoolean,
+		"inferenceProvider":           typeEnum,
+		"coworkEgressAllowedHosts":    typeStringArray,
+		"managedMcpServers":           typeJSONString,
+		"otlpEndpoint":                typeURL,
+		"autoUpdaterEnforcementHours": typeInteger,
+		"otlpHeaders":                 typeString,
+	}
+	for name, wantType := range want {
+		k, ok := byName[name]
+		if !ok {
+			t.Errorf("missing extracted key %q", name)
+			continue
+		}
+		if k.Type != wantType {
+			t.Errorf("key %q: Type = %q, want %q", name, k.Type, wantType)
+		}
+	}
+
+	// Spot-check metadata parsing.
+	bootstrap := byName["inferenceProvider"]
+	if len(bootstrap.EnumValues) != 4 {
+		t.Errorf("inferenceProvider enum: got %v, want 4 values", bootstrap.EnumValues)
+	}
+	if bootstrap.Title != "Inference provider" {
+		t.Errorf("inferenceProvider title = %q", bootstrap.Title)
+	}
+	wantScopes := []string{"3p", "3p-bootstrap"}
+	if len(bootstrap.Scopes) != len(wantScopes) {
+		t.Fatalf("scopes = %v, want %v", bootstrap.Scopes, wantScopes)
+	}
+	for i, s := range bootstrap.Scopes {
+		if s != wantScopes[i] {
+			t.Errorf("scopes[%d] = %q, want %q", i, s, wantScopes[i])
+		}
+	}
+
+	mcp := byName["managedMcpServers"]
+	if !mcp.Sensitive {
+		t.Error("managedMcpServers Sensitive should be true")
+	}
+	if mcp.AppMin != "1.2.0" {
+		t.Errorf("managedMcpServers appMin = %q", mcp.AppMin)
+	}
+
+	legacy := byName["isDesktopExtensionEnabled"]
+	if legacy.LegacyAlias != "isDxtEnabled" {
+		t.Errorf("legacyAlias = %q", legacy.LegacyAlias)
+	}
+}
+
+func TestMatchBraceSkipsStrings(t *testing.T) {
+	// Braces inside strings must not affect depth counting.
+	src := `{ "k": "{nested}", "t": ` + "`template ${1+2} end`" + ` }trailer`
+	end, err := matchBrace(src, 0)
+	if err != nil {
+		t.Fatalf("matchBrace: %v", err)
+	}
+	if src[end] != '}' {
+		t.Fatalf("expected } at %d, got %q", end, src[end])
+	}
+	if !strings.HasPrefix(src[end+1:], "trailer") {
+		t.Errorf("content after } = %q", src[end+1:])
+	}
+}
+
+func TestLocateMeCallWithWhitespace(t *testing.T) {
+	src := "foo();\n\nFJ   =   me (  { a: 1 }   )\n;"
+	_, body, err := locateMeCall(src)
+	if err != nil {
+		t.Fatalf("locateMeCall: %v", err)
+	}
+	if !strings.Contains(body, "a: 1") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestParseSchemaLiteralMissing(t *testing.T) {
+	_, err := parseSchemaLiteral("no schema here")
+	if err == nil {
+		t.Fatal("expected error when FJ=me({...}) is absent")
+	}
+}
+
+func TestUnquoteJSString(t *testing.T) {
+	cases := map[string]string{
+		`hello\nworld`: "hello\nworld",
+		`a\\b`:         `a\b`,
+		`x\tY`:         "x\tY",
+		`A`:            "A",
+	}
+	for in, want := range cases {
+		if got := unquoteJSString(in); got != want {
+			t.Errorf("unquoteJSString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,0 +1,228 @@
+// Package schema provides a typed, embedded representation of Claude
+// Desktop's MDM key schema. Consumers (profile encoder, doctor,
+// validator) read from here; they never touch the Claude.app binary
+// directly. The authoritative data file (schema.json) is extracted from
+// a Claude Desktop release via internal/schema/extract and embedded at
+// build time.
+package schema
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sync"
+)
+
+// Type identifies the MDM value type. Values map to the expression the
+// extractor saw for each key in Claude Desktop's source.
+type Type string
+
+const (
+	TypeString      Type = "string"      // MA() — plain string.
+	TypeBoolean     Type = "boolean"     // Hi() — boolean.
+	TypeInteger     Type = "integer"     // PsA.number().int() — 64-bit integer.
+	TypeStringArray Type = "stringArray" // Li(MA()) — JSON array of strings.
+	TypeJSONString  Type = "jsonString"  // Serialized JSON (managedMcpServers, inferenceModels).
+	TypeURL         Type = "url"         // YsA / r_ — HTTPS URL string.
+	TypeEnum        Type = "enum"        // Ds([...]) — restricted string values.
+)
+
+// Scope identifies which deployment mode a key applies to.
+type Scope string
+
+const (
+	ScopeThirdParty          Scope = "3p"
+	ScopeFirstParty          Scope = "1p"
+	ScopeThirdPartyBootstrap Scope = "3p-bootstrap"
+)
+
+// Key describes one MDM configuration key.
+type Key struct {
+	Name             string   `json:"name"`
+	Type             Type     `json:"type"`
+	Scopes           []Scope  `json:"scopes"`
+	AppMin           string   `json:"appMin,omitempty"`
+	Title            string   `json:"title"`
+	Description      string   `json:"description"`
+	Example          any      `json:"example,omitempty"`
+	LegacyAlias      string   `json:"legacyAlias,omitempty"`
+	Sensitive        bool     `json:"sensitive,omitempty"`
+	Provider         string   `json:"provider,omitempty"`
+	Category         string   `json:"category,omitempty"`
+	EnumValues       []string `json:"enumValues,omitempty"`
+	Default          any      `json:"default,omitempty"`
+	ExtractedFromApp string   `json:"-"`
+}
+
+// Schema is the loaded top-level structure.
+type Schema struct {
+	Version                 string `json:"version"`
+	ExtractedFromAppVersion string `json:"extractedFromAppVersion"`
+	Keys                    []Key  `json:"keys"`
+}
+
+//go:embed schema.json
+var embeddedJSON []byte
+
+var (
+	loadOnce   sync.Once
+	loaded     *Schema
+	loadErr    error
+	indexByKey map[string]*Key
+)
+
+// Load returns the embedded schema. The returned value is shared
+// between callers — do not mutate it. Panics if the embedded JSON is
+// malformed (that indicates a broken binary, which is unrecoverable).
+func Load() *Schema {
+	loadOnce.Do(parseEmbedded)
+	if loadErr != nil {
+		panic(fmt.Errorf("schema: embedded schema.json is invalid: %w", loadErr))
+	}
+	return loaded
+}
+
+func parseEmbedded() {
+	var s Schema
+	if err := json.Unmarshal(embeddedJSON, &s); err != nil {
+		loadErr = err
+		return
+	}
+	// Propagate the schema-level app version to each key so downstream
+	// consumers (e.g. doctor reporting) can answer "which Claude
+	// release did we extract this from?" without carrying the parent
+	// Schema around.
+	for i := range s.Keys {
+		s.Keys[i].ExtractedFromApp = s.ExtractedFromAppVersion
+	}
+
+	idx := make(map[string]*Key, len(s.Keys))
+	for i := range s.Keys {
+		idx[s.Keys[i].Name] = &s.Keys[i]
+	}
+
+	loaded = &s
+	indexByKey = idx
+}
+
+// Find returns the Key with the given name, or nil if absent. The
+// returned pointer references the shared Schema — do not mutate it.
+func (s *Schema) Find(name string) *Key {
+	if s == nil {
+		return nil
+	}
+	// Fast path: if s is the package's cached Schema, reuse the
+	// pre-built index so lookups are O(1).
+	if s == loaded && indexByKey != nil {
+		return indexByKey[name]
+	}
+	for i := range s.Keys {
+		if s.Keys[i].Name == name {
+			return &s.Keys[i]
+		}
+	}
+	return nil
+}
+
+// Validate checks a value against a Key's type and enum constraints.
+// Returns nil on success or a descriptive error. Validate does not
+// parse/inspect jsonString or url content — v0.2 only checks that the
+// Go type is a string for those; full JSON/URL validation is left to
+// the caller (profile package) when needed.
+func (k *Key) Validate(value any) error {
+	if k == nil {
+		return fmt.Errorf("schema: Validate called on nil Key")
+	}
+	if value == nil {
+		return fmt.Errorf("schema: key %q: value is nil", k.Name)
+	}
+
+	switch k.Type {
+	case TypeBoolean:
+		if _, ok := value.(bool); !ok {
+			return typeError(k, "bool", value)
+		}
+		return nil
+
+	case TypeInteger:
+		return validateInteger(k, value)
+
+	case TypeString:
+		if _, ok := value.(string); !ok {
+			return typeError(k, "string", value)
+		}
+		return nil
+
+	case TypeStringArray:
+		return validateStringArray(k, value)
+
+	case TypeJSONString:
+		// v0.2: we only require a string here. Encoders that need to
+		// emit a plist <array>/<dict> parse the JSON themselves.
+		if _, ok := value.(string); !ok {
+			return typeError(k, "string (serialized JSON)", value)
+		}
+		return nil
+
+	case TypeURL:
+		// v0.2: we only require a string. Higher layers may later
+		// enforce "https scheme required" — out of scope here.
+		if _, ok := value.(string); !ok {
+			return typeError(k, "string (URL)", value)
+		}
+		return nil
+
+	case TypeEnum:
+		s, ok := value.(string)
+		if !ok {
+			return typeError(k, "string (enum)", value)
+		}
+		for _, allowed := range k.EnumValues {
+			if s == allowed {
+				return nil
+			}
+		}
+		return fmt.Errorf(
+			"schema: key %q: value %q is not one of allowed enum values %v",
+			k.Name, s, k.EnumValues,
+		)
+
+	default:
+		return fmt.Errorf("schema: key %q has unknown type %q", k.Name, k.Type)
+	}
+}
+
+// validateInteger accepts the integer-like Go numeric kinds. Floats
+// (even whole-valued like 1.0) are rejected because JSON-decoded
+// numbers land in float64 and callers should convert explicitly before
+// passing them in.
+func validateInteger(k *Key, value any) error {
+	switch v := value.(type) {
+	case int, int8, int16, int32, int64:
+		return nil
+	case uint, uint8, uint16, uint32:
+		return nil
+	case uint64:
+		if v > math.MaxInt64 {
+			return fmt.Errorf("schema: key %q: uint64 value %d exceeds int64 range", k.Name, v)
+		}
+		return nil
+	default:
+		return typeError(k, "integer", value)
+	}
+}
+
+// validateStringArray accepts only []string. []any with all-string
+// elements is intentionally rejected: callers should pass the concrete
+// type so misuse (e.g. passing an array of numbers) is caught.
+func validateStringArray(k *Key, value any) error {
+	if _, ok := value.([]string); ok {
+		return nil
+	}
+	return typeError(k, "[]string", value)
+}
+
+func typeError(k *Key, want string, got any) error {
+	return fmt.Errorf("schema: key %q: expected %s, got %T", k.Name, want, got)
+}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -1,0 +1,204 @@
+package schema
+
+import (
+	"testing"
+)
+
+// TestSchemaHasAllKeys is the authoritative size gate used by
+// docs/execution/verify.sh task-01. Raising the minimum is fine;
+// dropping it silently is not.
+func TestSchemaHasAllKeys(t *testing.T) {
+	s := Load()
+	if s == nil {
+		t.Fatal("Load() returned nil")
+	}
+	const minKeys = 51
+	if got := len(s.Keys); got < minKeys {
+		t.Fatalf("schema has %d keys, want >= %d", got, minKeys)
+	}
+	if s.Version == "" {
+		t.Error("Schema.Version is empty")
+	}
+	if s.ExtractedFromAppVersion == "" {
+		t.Error("Schema.ExtractedFromAppVersion is empty")
+	}
+}
+
+func TestLoadPropagatesAppVersion(t *testing.T) {
+	s := Load()
+	for i := range s.Keys {
+		k := &s.Keys[i]
+		if k.ExtractedFromApp != s.ExtractedFromAppVersion {
+			t.Errorf(
+				"key %q: ExtractedFromApp=%q, want %q",
+				k.Name, k.ExtractedFromApp, s.ExtractedFromAppVersion,
+			)
+		}
+	}
+}
+
+func TestFindReturnsKnownKey(t *testing.T) {
+	s := Load()
+
+	cases := []struct {
+		name         string
+		wantType     Type
+		wantSensitve bool
+		wantScope    Scope
+	}{
+		{name: "inferenceProvider", wantType: TypeEnum, wantScope: ScopeThirdParty},
+		{name: "managedMcpServers", wantType: TypeJSONString, wantSensitve: true, wantScope: ScopeThirdParty},
+		{name: "coworkEgressAllowedHosts", wantType: TypeStringArray, wantScope: ScopeThirdParty},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			k := s.Find(tc.name)
+			if k == nil {
+				t.Fatalf("Find(%q) = nil; want a key", tc.name)
+			}
+			if k.Name != tc.name {
+				t.Errorf("Name = %q, want %q", k.Name, tc.name)
+			}
+			if k.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", k.Type, tc.wantType)
+			}
+			if k.Sensitive != tc.wantSensitve {
+				t.Errorf("Sensitive = %v, want %v", k.Sensitive, tc.wantSensitve)
+			}
+			found := false
+			for _, s := range k.Scopes {
+				if s == tc.wantScope {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("scope %q not present in %v", tc.wantScope, k.Scopes)
+			}
+		})
+	}
+}
+
+func TestInferenceProviderEnumValues(t *testing.T) {
+	s := Load()
+	k := s.Find("inferenceProvider")
+	if k == nil {
+		t.Fatal("inferenceProvider missing")
+	}
+	want := map[string]bool{"bedrock": true, "vertex": true, "gateway": true, "foundry": true}
+	if len(k.EnumValues) == 0 {
+		t.Fatal("inferenceProvider has no enumValues")
+	}
+	for _, v := range k.EnumValues {
+		if !want[v] {
+			t.Errorf("unexpected enum value %q", v)
+		}
+		delete(want, v)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing expected enum values: %v", want)
+	}
+}
+
+func TestFindUnknownKeyReturnsNil(t *testing.T) {
+	s := Load()
+	if k := s.Find("thisKeyDoesNotExist"); k != nil {
+		t.Errorf("Find(unknown) = %+v, want nil", k)
+	}
+	if k := s.Find(""); k != nil {
+		t.Errorf("Find(\"\") = %+v, want nil", k)
+	}
+}
+
+func TestLoadIsSingleton(t *testing.T) {
+	a := Load()
+	b := Load()
+	if a != b {
+		t.Errorf("Load() returned different pointers: %p vs %p", a, b)
+	}
+}
+
+func TestFindOnNilReceiverIsSafe(t *testing.T) {
+	var s *Schema
+	if k := s.Find("inferenceProvider"); k != nil {
+		t.Errorf("nil-receiver Find() = %+v, want nil", k)
+	}
+}
+
+func TestDefaultFieldPreserved(t *testing.T) {
+	// The schema.json records per-key defaults (e.g. isDesktopExtensionEnabled
+	// defaults to true, disableAutoUpdates defaults to false). Downstream
+	// consumers rely on these to distinguish "unset" from "set to the default"
+	// when rendering diffs or status reports. The JSON field must round-trip
+	// into Key.Default rather than being silently dropped.
+	s := Load()
+	k := s.Find("isDesktopExtensionEnabled")
+	if k == nil {
+		t.Fatal("Find(\"isDesktopExtensionEnabled\") returned nil")
+	}
+	if k.Default == nil {
+		t.Errorf("isDesktopExtensionEnabled.Default = nil; schema.json declares a default — field was dropped during Unmarshal")
+	}
+	// Spot-check one more: disableAutoUpdates defaults to false in schema.json.
+	if k := s.Find("disableAutoUpdates"); k != nil && k.Default == nil {
+		t.Errorf("disableAutoUpdates.Default = nil; schema.json declares a default")
+	}
+}
+
+func TestAllKeysHaveSupportedType(t *testing.T) {
+	s := Load()
+	supported := map[Type]bool{
+		TypeString: true, TypeBoolean: true, TypeInteger: true,
+		TypeStringArray: true, TypeJSONString: true, TypeURL: true,
+		TypeEnum: true,
+	}
+	seen := make(map[string]bool, len(s.Keys))
+	for i := range s.Keys {
+		k := &s.Keys[i]
+		if !supported[k.Type] {
+			t.Errorf("key %q has unsupported type %q", k.Name, k.Type)
+		}
+		if k.Name == "" {
+			t.Errorf("key at index %d has empty Name", i)
+		}
+		if seen[k.Name] {
+			t.Errorf("duplicate key Name %q", k.Name)
+		}
+		seen[k.Name] = true
+		// Note: some keys in the current schema.json carry no `scopes`
+		// (e.g. bootstrap* which is inherently 3p-bootstrap and the
+		// bedrock service tier which is bedrock-only). We do not
+		// enforce a non-empty Scopes list here — but any scope that
+		// IS present must be one of the three known values.
+		for _, sc := range k.Scopes {
+			if sc != ScopeThirdParty && sc != ScopeFirstParty && sc != ScopeThirdPartyBootstrap {
+				t.Errorf("key %q has unknown scope %q", k.Name, sc)
+			}
+		}
+		if k.Type == TypeEnum && len(k.EnumValues) == 0 {
+			t.Errorf("key %q is enum but has no EnumValues", k.Name)
+		}
+	}
+}
+
+func TestFindOnCustomSchemaDoesNotTouchCache(t *testing.T) {
+	custom := &Schema{
+		Version:                 "test",
+		ExtractedFromAppVersion: "0.0.0",
+		Keys: []Key{
+			{Name: "alpha", Type: TypeBoolean, Scopes: []Scope{ScopeThirdParty}},
+			{Name: "beta", Type: TypeString, Scopes: []Scope{ScopeThirdParty}},
+		},
+	}
+	if custom.Find("alpha") == nil {
+		t.Error("Find(alpha) on custom schema returned nil")
+	}
+	if custom.Find("missing") != nil {
+		t.Error("Find(missing) on custom schema returned non-nil")
+	}
+	// The embedded cache must not be affected.
+	if Load().Find("alpha") != nil {
+		t.Error("custom-schema lookup leaked into embedded cache")
+	}
+}

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -1,0 +1,157 @@
+package schema
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	boolKey := &Key{Name: "flag", Type: TypeBoolean, Scopes: []Scope{ScopeThirdParty}}
+	intKey := &Key{Name: "n", Type: TypeInteger, Scopes: []Scope{ScopeThirdParty}}
+	strKey := &Key{Name: "s", Type: TypeString, Scopes: []Scope{ScopeThirdParty}}
+	saKey := &Key{Name: "arr", Type: TypeStringArray, Scopes: []Scope{ScopeThirdParty}}
+	jsonKey := &Key{Name: "j", Type: TypeJSONString, Scopes: []Scope{ScopeThirdParty}}
+	urlKey := &Key{Name: "u", Type: TypeURL, Scopes: []Scope{ScopeThirdParty}}
+	enumKey := &Key{
+		Name:       "e",
+		Type:       TypeEnum,
+		Scopes:     []Scope{ScopeThirdParty},
+		EnumValues: []string{"bedrock", "vertex", "gateway", "foundry"},
+	}
+	unknownTypeKey := &Key{Name: "mystery", Type: Type("martian"), Scopes: []Scope{ScopeThirdParty}}
+
+	cases := []struct {
+		label   string
+		key     *Key
+		value   any
+		wantErr bool
+		errSubs string // substring to match when wantErr is true
+	}{
+		// boolean
+		{label: "bool/true", key: boolKey, value: true},
+		{label: "bool/false", key: boolKey, value: false},
+		{label: "bool/reject-string", key: boolKey, value: "true", wantErr: true, errSubs: "expected bool"},
+		{label: "bool/reject-int", key: boolKey, value: 1, wantErr: true, errSubs: "expected bool"},
+		{label: "bool/reject-nil", key: boolKey, value: nil, wantErr: true, errSubs: "value is nil"},
+
+		// integer
+		{label: "int/int", key: intKey, value: 42},
+		{label: "int/int64", key: intKey, value: int64(1 << 40)},
+		{label: "int/int32", key: intKey, value: int32(5)},
+		{label: "int/uint", key: intKey, value: uint(5)},
+		{label: "int/uint64-ok", key: intKey, value: uint64(math.MaxInt64)},
+		{label: "int/uint64-too-big", key: intKey, value: uint64(math.MaxUint64), wantErr: true, errSubs: "exceeds int64"},
+		{label: "int/reject-float", key: intKey, value: 1.5, wantErr: true, errSubs: "expected integer"},
+		{label: "int/reject-float-whole", key: intKey, value: 1.0, wantErr: true, errSubs: "expected integer"},
+		{label: "int/reject-string", key: intKey, value: "42", wantErr: true, errSubs: "expected integer"},
+		{label: "int/reject-bool", key: intKey, value: true, wantErr: true, errSubs: "expected integer"},
+
+		// string
+		{label: "string/ok", key: strKey, value: "hello"},
+		{label: "string/empty", key: strKey, value: ""},
+		{label: "string/reject-bool", key: strKey, value: false, wantErr: true, errSubs: "expected string"},
+		{label: "string/reject-int", key: strKey, value: 1, wantErr: true, errSubs: "expected string"},
+		{label: "string/reject-nil", key: strKey, value: nil, wantErr: true, errSubs: "value is nil"},
+
+		// stringArray
+		{label: "sa/ok", key: saKey, value: []string{"a", "b"}},
+		{label: "sa/empty", key: saKey, value: []string{}},
+		{label: "sa/reject-int-slice", key: saKey, value: []int{1, 2}, wantErr: true, errSubs: "expected []string"},
+		{label: "sa/reject-any-slice", key: saKey, value: []any{"a"}, wantErr: true, errSubs: "expected []string"},
+		{label: "sa/reject-string", key: saKey, value: "a,b", wantErr: true, errSubs: "expected []string"},
+
+		// jsonString — v0.2 only checks that it's a string
+		{label: "json/ok-string", key: jsonKey, value: `[{"name":"x"}]`},
+		{label: "json/reject-struct", key: jsonKey, value: struct{}{}, wantErr: true, errSubs: "expected string"},
+
+		// url — v0.2 only checks that it's a string
+		{label: "url/ok", key: urlKey, value: "https://example.com"},
+		{label: "url/empty-allowed-at-v0.2", key: urlKey, value: ""},
+		{label: "url/reject-int", key: urlKey, value: 1, wantErr: true, errSubs: "expected string"},
+
+		// enum
+		{label: "enum/bedrock", key: enumKey, value: "bedrock"},
+		{label: "enum/vertex", key: enumKey, value: "vertex"},
+		{label: "enum/reject-unknown", key: enumKey, value: "openai", wantErr: true, errSubs: "allowed enum values"},
+		{label: "enum/reject-empty", key: enumKey, value: "", wantErr: true, errSubs: "allowed enum values"},
+		{label: "enum/reject-non-string", key: enumKey, value: 42, wantErr: true, errSubs: "expected string"},
+
+		// unknown type
+		{label: "unknown-type", key: unknownTypeKey, value: "whatever", wantErr: true, errSubs: "unknown type"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			err := tc.key.Validate(tc.value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Validate(%v) = nil error, want error containing %q", tc.value, tc.errSubs)
+				}
+				if tc.errSubs != "" && !strings.Contains(err.Error(), tc.errSubs) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errSubs)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate(%v) unexpected error: %v", tc.value, err)
+			}
+		})
+	}
+}
+
+func TestValidateNilReceiver(t *testing.T) {
+	var k *Key
+	err := k.Validate(true)
+	if err == nil {
+		t.Fatal("nil-receiver Validate returned nil error")
+	}
+	if !strings.Contains(err.Error(), "nil Key") {
+		t.Errorf("error %q should mention nil Key", err.Error())
+	}
+}
+
+// TestValidateAgainstRealSchema pins a few canonical keys from the
+// embedded schema, catching accidental regressions where a key's
+// declared type in schema.json diverges from what Validate accepts.
+func TestValidateAgainstRealSchema(t *testing.T) {
+	s := Load()
+
+	boolKey := s.Find("isDesktopExtensionEnabled")
+	if boolKey == nil {
+		t.Fatal("isDesktopExtensionEnabled missing")
+	}
+	if err := boolKey.Validate(true); err != nil {
+		t.Errorf("bool key rejected a bool: %v", err)
+	}
+	if err := boolKey.Validate("true"); err == nil {
+		t.Error("bool key accepted a string")
+	}
+
+	enumKey := s.Find("inferenceProvider")
+	if enumKey == nil {
+		t.Fatal("inferenceProvider missing")
+	}
+	if err := enumKey.Validate("bedrock"); err != nil {
+		t.Errorf("enum key rejected bedrock: %v", err)
+	}
+	if err := enumKey.Validate("openai"); err == nil {
+		t.Error("enum key accepted 'openai'")
+	}
+
+	saKey := s.Find("coworkEgressAllowedHosts")
+	if saKey == nil {
+		t.Fatal("coworkEgressAllowedHosts missing")
+	}
+	if err := saKey.Validate([]string{"example.com"}); err != nil {
+		t.Errorf("stringArray key rejected a []string: %v", err)
+	}
+
+	jsonKey := s.Find("managedMcpServers")
+	if jsonKey == nil {
+		t.Fatal("managedMcpServers missing")
+	}
+	if err := jsonKey.Validate(`[]`); err != nil {
+		t.Errorf("jsonString key rejected a string: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the \`internal/schema/\` package per \`specs/schema.md\`:

- \`Key\`, \`Type\`, \`Scope\`, \`Schema\` types
- \`//go:embed schema.json\` with \`sync.Once\`-cached \`Load()\`
- \`Find()\` lookup; \`Validate()\` per-type value check
- \`//go:build extract\` maintainer tool for regenerating schema.json from future Claude.app releases
- Tests: TestSchemaHasAllKeys (≥51), TestFindReturnsKnownKey, TestFindUnknownKeyReturnsNil, TestLoadIsSingleton, TestAllKeysHaveSupportedType, TestFindOnNilReceiverIsSafe, TestDefaultFieldPreserved + per-type Validate edge cases

## Sparring trail

\`codex:rescue\` — 2 SHOULD-FIX, 0 MUST-FIX:

1. **Key struct missing \`Default\` field** — schema.json carries 16 \`default\` values that were being silently dropped. Fixed in-tree: added \`Default any \\\`json:\"default,omitempty\\\`\`\` + TestDefaultFieldPreserved test.
2. **validateInteger rejecting float64** — deferred. Spec says "accepts int/int64", which is intentional. JSON-consuming callers MUST convert \`float64\` to \`int\` before calling \`Validate\`. Documented risk; revisit in v0.3 if this becomes a footgun in practice.

NITs (no action): extract.go's 837-line size (acknowledged as one-off tool), loadErr being rarely re-read after sync.Once.

## Test plan

- [x] \`go test ./internal/schema/...\` green locally and under \`-race\`
- [x] Cross-build (darwin/windows/linux × amd64+arm64) clean
- [x] \`docs/execution/verify.sh task-01\` PASS
- [x] Sparring-approved (SHOULD-FIX #1 fixed)
- [ ] CI green on this PR

## Downstream

Task-03 (internal/profile) + task-apply (internal/managed) + task-09 (doctor) depend on this merging.

## Note on extract binary

Running \`go build -tags extract ./internal/schema/extract/...\` locally produces a stray \`extract\` binary at repo root (not ideal). This is an issue with verify.sh, not this package. Will be fixed via a separate coordinator chore PR.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)