### PR TITLE
task-02: add internal/paths

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,231 @@
+// Package paths centralizes platform-specific filesystem and registry paths
+// used throughout cowork-mdm. It exists so other packages can avoid scattered
+// runtime.GOOS checks and so tests can simulate every supported OS from any
+// host via ForOS.
+//
+// The package is pure path arithmetic: it never touches the filesystem and
+// never creates directories. Returned paths are absolute on the OSes they
+// apply to, and empty strings on OSes where a given path does not apply.
+package paths
+
+import (
+	"os"
+	"path"
+	"strings"
+)
+
+// Provider returns platform-resolved paths. Returned paths are absolute on
+// the target platform. For paths that do not apply to a given OS, the
+// corresponding method returns an empty string.
+type Provider interface {
+	// ManagedPrefsPlist returns the path for Claude Desktop's managed plist on macOS.
+	// Returns empty string on non-macOS platforms.
+	ManagedPrefsPlist() string
+
+	// ManagedPrefsUserPlist returns the per-user variant:
+	//   /Library/Managed Preferences/<username>/com.anthropic.claudefordesktop.plist
+	// The app reads both; user-specific overrides system.
+	// Returns empty string on non-macOS platforms or when username is empty.
+	ManagedPrefsUserPlist(username string) string
+
+	// OrgPluginsDir returns Claude.app's hardcoded plugin directory.
+	//   darwin:  /Library/Application Support/Claude/org-plugins
+	//   windows: C:\Program Files\Claude\org-plugins
+	//   linux:   empty (unsupported)
+	OrgPluginsDir() string
+
+	// ClaudeAppPath returns the expected Claude Desktop install location.
+	//   darwin:  /Applications/Claude.app
+	//   windows: C:\Program Files\Claude\Claude.exe
+	//   linux:   empty (unsupported)
+	ClaudeAppPath() string
+
+	// UserSessionsDir returns the Claude-3p sessions dir for the current user.
+	//   darwin:  $HOME/Library/Application Support/Claude-3p/local-agent-mode-sessions
+	//   windows: $USERPROFILE\AppData\Roaming\Claude-3p\local-agent-mode-sessions
+	//   linux:   empty (unsupported)
+	// Returns empty string if the home directory cannot be resolved.
+	UserSessionsDir() string
+
+	// WindowsRegistryPath returns the MDM registry key path on Windows.
+	//   windows: SOFTWARE\Policies\Claude
+	//   other:   empty
+	WindowsRegistryPath() string
+
+	// LaunchAgentDir returns where to install per-user LaunchAgents on macOS.
+	//   darwin:  /Library/LaunchAgents
+	//   other:   empty
+	LaunchAgentDir() string
+}
+
+// Literal path constants. Pinned here (not per-OS file) so tests can assert
+// against them and so cross-OS simulation via ForOS works identically on
+// every host.
+const (
+	darwinManagedPrefsPlist    = "/Library/Managed Preferences/com.anthropic.claudefordesktop.plist"
+	darwinManagedPrefsUserRoot = "/Library/Managed Preferences"
+	darwinManagedPrefsLeaf     = "com.anthropic.claudefordesktop.plist"
+	darwinOrgPluginsDir        = "/Library/Application Support/Claude/org-plugins"
+	darwinClaudeAppPath        = "/Applications/Claude.app"
+	darwinLaunchAgentDir       = "/Library/LaunchAgents"
+	darwinUserSessionsRelative = "Library/Application Support/Claude-3p/local-agent-mode-sessions"
+
+	windowsOrgPluginsDir        = `C:\Program Files\Claude\org-plugins`
+	windowsClaudeAppPath        = `C:\Program Files\Claude\Claude.exe`
+	windowsRegistryPath         = `SOFTWARE\Policies\Claude`
+	windowsUserSessionsRelative = `AppData\Roaming\Claude-3p\local-agent-mode-sessions`
+)
+
+// homeResolver returns the user home directory for the target OS's conventions.
+// Exposed as a struct field so tests can inject a deterministic value.
+type homeResolver func() (string, error)
+
+// darwinProvider resolves macOS paths. Defined here (not build-gated) so
+// ForOS can simulate it from any platform.
+type darwinProvider struct {
+	// home resolves $HOME. nil means "read os.Getenv(\"HOME\") only".
+	home homeResolver
+}
+
+func (p darwinProvider) ManagedPrefsPlist() string {
+	return darwinManagedPrefsPlist
+}
+
+func (p darwinProvider) ManagedPrefsUserPlist(username string) string {
+	if username == "" {
+		return ""
+	}
+	// Use path.Join (not filepath.Join) so the result is a POSIX path with
+	// forward slashes regardless of the host OS running the simulation.
+	return path.Join(darwinManagedPrefsUserRoot, username, darwinManagedPrefsLeaf)
+}
+
+func (p darwinProvider) OrgPluginsDir() string {
+	return darwinOrgPluginsDir
+}
+
+func (p darwinProvider) ClaudeAppPath() string {
+	return darwinClaudeAppPath
+}
+
+func (p darwinProvider) UserSessionsDir() string {
+	home, err := p.resolveHome()
+	if err != nil || home == "" {
+		return ""
+	}
+	// path.Join keeps forward slashes so darwin simulation is deterministic
+	// on any host (including Windows CI runners). We do NOT trim trailing
+	// slashes from home because home="/" would then collapse to "" and
+	// produce a relative path, violating the absolute-path guarantee.
+	// path.Join already canonicalizes duplicate slashes internally.
+	return path.Join(home, darwinUserSessionsRelative)
+}
+
+func (p darwinProvider) WindowsRegistryPath() string {
+	return ""
+}
+
+func (p darwinProvider) LaunchAgentDir() string {
+	return darwinLaunchAgentDir
+}
+
+func (p darwinProvider) resolveHome() (string, error) {
+	if p.home != nil {
+		return p.home()
+	}
+	// Only honour $HOME. Avoid os.UserHomeDir() host fallback so
+	// ForOS("darwin") remains deterministic when executed from a
+	// non-darwin host (which would otherwise inject a backslash path on
+	// Windows). Callers get an empty UserSessionsDir() when $HOME is
+	// unset, matching the spec's "returns empty if unresolved" rule.
+	if h := os.Getenv("HOME"); h != "" {
+		return h, nil
+	}
+	return "", nil
+}
+
+// windowsProvider resolves Windows paths. Defined here (not build-gated) so
+// ForOS can simulate it from any platform.
+type windowsProvider struct {
+	// home resolves %USERPROFILE%. nil means "read os.Getenv(\"USERPROFILE\") only".
+	home homeResolver
+}
+
+func (p windowsProvider) ManagedPrefsPlist() string {
+	return ""
+}
+
+func (p windowsProvider) ManagedPrefsUserPlist(username string) string {
+	return ""
+}
+
+func (p windowsProvider) OrgPluginsDir() string {
+	return windowsOrgPluginsDir
+}
+
+func (p windowsProvider) ClaudeAppPath() string {
+	return windowsClaudeAppPath
+}
+
+func (p windowsProvider) UserSessionsDir() string {
+	home, err := p.resolveHome()
+	if err != nil || home == "" {
+		return ""
+	}
+	// Use backslash joining explicitly so the result is a valid Windows
+	// path regardless of the host OS running the code (important for
+	// ForOS("windows") on darwin/linux). Trim any trailing separator on
+	// the home prefix so we never emit a double-backslash.
+	home = strings.TrimRight(home, `\/`)
+	return home + `\` + windowsUserSessionsRelative
+}
+
+func (p windowsProvider) WindowsRegistryPath() string {
+	return windowsRegistryPath
+}
+
+func (p windowsProvider) LaunchAgentDir() string {
+	return ""
+}
+
+func (p windowsProvider) resolveHome() (string, error) {
+	if p.home != nil {
+		return p.home()
+	}
+	// Only honour %USERPROFILE%. Avoid os.UserHomeDir() host fallback so
+	// ForOS("windows") stays deterministic when running from a non-Windows
+	// host (which would otherwise return a POSIX path). When unset,
+	// UserSessionsDir() resolves to empty, matching the spec.
+	if h := os.Getenv("USERPROFILE"); h != "" {
+		return h, nil
+	}
+	return "", nil
+}
+
+// otherProvider is the empty-path provider used on unsupported platforms
+// (Linux, BSDs, etc.). Every method returns "" per spec.
+type otherProvider struct{}
+
+func (otherProvider) ManagedPrefsPlist() string                    { return "" }
+func (otherProvider) ManagedPrefsUserPlist(username string) string { return "" }
+func (otherProvider) OrgPluginsDir() string                        { return "" }
+func (otherProvider) ClaudeAppPath() string                        { return "" }
+func (otherProvider) UserSessionsDir() string                      { return "" }
+func (otherProvider) WindowsRegistryPath() string                  { return "" }
+func (otherProvider) LaunchAgentDir() string                       { return "" }
+
+// ForOS returns the Provider for a specific operating system identifier.
+// Intended for tests that need to simulate multiple OSes from a single host.
+//
+// Recognised values: "darwin", "windows". Any other value (including
+// "linux") returns the empty-path otherProvider.
+func ForOS(os string) Provider {
+	switch os {
+	case "darwin":
+		return darwinProvider{}
+	case "windows":
+		return windowsProvider{}
+	default:
+		return otherProvider{}
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -133,7 +133,7 @@ func (p darwinProvider) resolveHome() (string, error) {
 	if p.home != nil {
 		return p.home()
 	}
-	// Only honour $HOME. Avoid os.UserHomeDir() host fallback so
+	// Only honor $HOME. Avoid os.UserHomeDir() host fallback so
 	// ForOS("darwin") remains deterministic when executed from a
 	// non-darwin host (which would otherwise inject a backslash path on
 	// Windows). Callers get an empty UserSessionsDir() when $HOME is
@@ -192,7 +192,7 @@ func (p windowsProvider) resolveHome() (string, error) {
 	if p.home != nil {
 		return p.home()
 	}
-	// Only honour %USERPROFILE%. Avoid os.UserHomeDir() host fallback so
+	// Only honor %USERPROFILE%. Avoid os.UserHomeDir() host fallback so
 	// ForOS("windows") stays deterministic when running from a non-Windows
 	// host (which would otherwise return a POSIX path). When unset,
 	// UserSessionsDir() resolves to empty, matching the spec.
@@ -217,7 +217,7 @@ func (otherProvider) LaunchAgentDir() string                       { return "" }
 // ForOS returns the Provider for a specific operating system identifier.
 // Intended for tests that need to simulate multiple OSes from a single host.
 //
-// Recognised values: "darwin", "windows". Any other value (including
+// Recognized values: "darwin", "windows". Any other value (including
 // "linux") returns the empty-path otherProvider.
 func ForOS(os string) Provider {
 	switch os {

--- a/internal/paths/paths_darwin.go
+++ b/internal/paths/paths_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package paths
+
+// Default returns the Provider for the current operating system (darwin).
+func Default() Provider {
+	return darwinProvider{}
+}

--- a/internal/paths/paths_other.go
+++ b/internal/paths/paths_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !windows
+
+package paths
+
+// Default returns the Provider for the current operating system. On
+// unsupported platforms (linux, BSDs, etc.) every path is an empty string,
+// letting callers treat the absence uniformly.
+func Default() Provider {
+	return otherProvider{}
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TestForOS_Darwin_StaticPaths pins the literal macOS paths that other
-// packages depend on. Changing any of these is a behavioural break for
+// packages depend on. Changing any of these is a behavioral break for
 // cowork-mdm's MDM payloads and should force a spec update.
 func TestForOS_Darwin_StaticPaths(t *testing.T) {
 	p := ForOS("darwin")
@@ -92,7 +92,7 @@ func TestDarwinProvider_UserSessionsDir_HomeInjection(t *testing.T) {
 }
 
 // TestDarwinProvider_UserSessionsDir_EnvFallback ensures the default
-// resolver honours $HOME when no injection is provided. We set the env
+// resolver honors $HOME when no injection is provided. We set the env
 // for the test and restore it afterwards.
 func TestDarwinProvider_UserSessionsDir_EnvFallback(t *testing.T) {
 	t.Setenv("HOME", "/Users/envtest")
@@ -178,7 +178,7 @@ func TestWindowsProvider_UserSessionsDir_HomeInjection(t *testing.T) {
 }
 
 // TestWindowsProvider_UserSessionsDir_EnvFallback ensures the default
-// resolver honours %USERPROFILE%.
+// resolver honors %USERPROFILE%.
 func TestWindowsProvider_UserSessionsDir_EnvFallback(t *testing.T) {
 	t.Setenv("USERPROFILE", `C:\Users\envtest`)
 	p := windowsProvider{}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,253 @@
+package paths
+
+import (
+	"os"
+	"testing"
+)
+
+// TestForOS_Darwin_StaticPaths pins the literal macOS paths that other
+// packages depend on. Changing any of these is a behavioural break for
+// cowork-mdm's MDM payloads and should force a spec update.
+func TestForOS_Darwin_StaticPaths(t *testing.T) {
+	p := ForOS("darwin")
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"ManagedPrefsPlist", p.ManagedPrefsPlist(), "/Library/Managed Preferences/com.anthropic.claudefordesktop.plist"},
+		{"OrgPluginsDir", p.OrgPluginsDir(), "/Library/Application Support/Claude/org-plugins"},
+		{"ClaudeAppPath", p.ClaudeAppPath(), "/Applications/Claude.app"},
+		{"LaunchAgentDir", p.LaunchAgentDir(), "/Library/LaunchAgents"},
+		{"WindowsRegistryPath", p.WindowsRegistryPath(), ""},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("darwin %s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestForOS_Darwin_ManagedPrefsUserPlist exercises the per-user override
+// rule: username parameter is required and is not read from the environment.
+func TestForOS_Darwin_ManagedPrefsUserPlist(t *testing.T) {
+	p := ForOS("darwin")
+
+	cases := []struct {
+		name     string
+		username string
+		want     string
+	}{
+		{"typical lowercase username", "alice", "/Library/Managed Preferences/alice/com.anthropic.claudefordesktop.plist"},
+		{"username with digits", "user42", "/Library/Managed Preferences/user42/com.anthropic.claudefordesktop.plist"},
+		{"username with dot", "corp.user", "/Library/Managed Preferences/corp.user/com.anthropic.claudefordesktop.plist"},
+		{"empty username returns empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := p.ManagedPrefsUserPlist(tc.username); got != tc.want {
+				t.Errorf("ManagedPrefsUserPlist(%q) = %q, want %q", tc.username, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestForOS_Darwin_UserSessionsDir_HomeInjection verifies the injectable
+// seam for testing cross-platform. We build a darwinProvider directly
+// because ForOS does not expose the injection, and ForOS's default is
+// covered separately by the env-driven test below.
+func TestDarwinProvider_UserSessionsDir_HomeInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		home string
+		want string
+	}{
+		{"standard home", "/Users/alice", "/Users/alice/Library/Application Support/Claude-3p/local-agent-mode-sessions"},
+		{"home with trailing slash is preserved verbatim", "/Users/bob/", "/Users/bob/Library/Application Support/Claude-3p/local-agent-mode-sessions"},
+		{"home is root slash — result must stay absolute", "/", "/Library/Application Support/Claude-3p/local-agent-mode-sessions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := darwinProvider{home: func() (string, error) { return tc.home, nil }}
+			if got := p.UserSessionsDir(); got != tc.want {
+				t.Errorf("UserSessionsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("empty home returns empty", func(t *testing.T) {
+		p := darwinProvider{home: func() (string, error) { return "", nil }}
+		if got := p.UserSessionsDir(); got != "" {
+			t.Errorf("UserSessionsDir() = %q, want empty", got)
+		}
+	})
+
+	t.Run("home resolver error returns empty", func(t *testing.T) {
+		p := darwinProvider{home: func() (string, error) { return "/unused", os.ErrNotExist }}
+		if got := p.UserSessionsDir(); got != "" {
+			t.Errorf("UserSessionsDir() on resolver error = %q, want empty", got)
+		}
+	})
+}
+
+// TestDarwinProvider_UserSessionsDir_EnvFallback ensures the default
+// resolver honours $HOME when no injection is provided. We set the env
+// for the test and restore it afterwards.
+func TestDarwinProvider_UserSessionsDir_EnvFallback(t *testing.T) {
+	t.Setenv("HOME", "/Users/envtest")
+	p := darwinProvider{} // no injection
+	want := "/Users/envtest/Library/Application Support/Claude-3p/local-agent-mode-sessions"
+	if got := p.UserSessionsDir(); got != want {
+		t.Errorf("UserSessionsDir() = %q, want %q", got, want)
+	}
+}
+
+// TestDarwinProvider_UserSessionsDir_EnvUnset verifies that simulating
+// darwin from a host with no HOME env returns the documented empty
+// string (and does NOT leak the host os.UserHomeDir value, which on
+// Windows would be a backslash path).
+func TestDarwinProvider_UserSessionsDir_EnvUnset(t *testing.T) {
+	t.Setenv("HOME", "")
+	p := darwinProvider{}
+	if got := p.UserSessionsDir(); got != "" {
+		t.Errorf("UserSessionsDir() with HOME unset = %q, want empty", got)
+	}
+}
+
+// TestForOS_Windows_StaticPaths pins the literal Windows paths.
+func TestForOS_Windows_StaticPaths(t *testing.T) {
+	p := ForOS("windows")
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"OrgPluginsDir", p.OrgPluginsDir(), `C:\Program Files\Claude\org-plugins`},
+		{"ClaudeAppPath", p.ClaudeAppPath(), `C:\Program Files\Claude\Claude.exe`},
+		{"WindowsRegistryPath", p.WindowsRegistryPath(), `SOFTWARE\Policies\Claude`},
+		{"ManagedPrefsPlist", p.ManagedPrefsPlist(), ""},
+		{"ManagedPrefsUserPlist(non-empty)", p.ManagedPrefsUserPlist("alice"), ""},
+		{"ManagedPrefsUserPlist(empty)", p.ManagedPrefsUserPlist(""), ""},
+		{"LaunchAgentDir", p.LaunchAgentDir(), ""},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("windows %s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestWindowsProvider_UserSessionsDir_HomeInjection verifies the Windows
+// home seam and the backslash joining (which must be deterministic across
+// darwin/linux/windows hosts so ForOS simulations stay correct).
+func TestWindowsProvider_UserSessionsDir_HomeInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		home string
+		want string
+	}{
+		{"typical userprofile", `C:\Users\alice`, `C:\Users\alice\AppData\Roaming\Claude-3p\local-agent-mode-sessions`},
+		{"non-standard drive", `D:\Profiles\bob`, `D:\Profiles\bob\AppData\Roaming\Claude-3p\local-agent-mode-sessions`},
+		{"trailing backslash is trimmed", `C:\Users\alice\`, `C:\Users\alice\AppData\Roaming\Claude-3p\local-agent-mode-sessions`},
+		{"trailing forward slash is trimmed", `C:\Users\alice/`, `C:\Users\alice\AppData\Roaming\Claude-3p\local-agent-mode-sessions`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := windowsProvider{home: func() (string, error) { return tc.home, nil }}
+			if got := p.UserSessionsDir(); got != tc.want {
+				t.Errorf("UserSessionsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("empty userprofile returns empty", func(t *testing.T) {
+		p := windowsProvider{home: func() (string, error) { return "", nil }}
+		if got := p.UserSessionsDir(); got != "" {
+			t.Errorf("UserSessionsDir() = %q, want empty", got)
+		}
+	})
+
+	t.Run("resolver error returns empty", func(t *testing.T) {
+		p := windowsProvider{home: func() (string, error) { return "/unused", os.ErrNotExist }}
+		if got := p.UserSessionsDir(); got != "" {
+			t.Errorf("UserSessionsDir() on resolver error = %q, want empty", got)
+		}
+	})
+}
+
+// TestWindowsProvider_UserSessionsDir_EnvFallback ensures the default
+// resolver honours %USERPROFILE%.
+func TestWindowsProvider_UserSessionsDir_EnvFallback(t *testing.T) {
+	t.Setenv("USERPROFILE", `C:\Users\envtest`)
+	p := windowsProvider{}
+	want := `C:\Users\envtest\AppData\Roaming\Claude-3p\local-agent-mode-sessions`
+	if got := p.UserSessionsDir(); got != want {
+		t.Errorf("UserSessionsDir() = %q, want %q", got, want)
+	}
+}
+
+// TestWindowsProvider_UserSessionsDir_EnvUnset verifies that simulating
+// Windows from a host with no USERPROFILE env returns the documented
+// empty string (no host UserHomeDir leakage, which on darwin/linux
+// would be a POSIX path).
+func TestWindowsProvider_UserSessionsDir_EnvUnset(t *testing.T) {
+	t.Setenv("USERPROFILE", "")
+	p := windowsProvider{}
+	if got := p.UserSessionsDir(); got != "" {
+		t.Errorf("UserSessionsDir() with USERPROFILE unset = %q, want empty", got)
+	}
+}
+
+// TestForOS_Other_AllEmpty checks that unsupported platforms return empty
+// strings everywhere so callers can treat "unsupported" uniformly.
+func TestForOS_Other_AllEmpty(t *testing.T) {
+	for _, osName := range []string{"linux", "freebsd", "openbsd", "netbsd", "", "unknown"} {
+		t.Run(osName, func(t *testing.T) {
+			p := ForOS(osName)
+			if got := p.ManagedPrefsPlist(); got != "" {
+				t.Errorf("%s ManagedPrefsPlist = %q, want empty", osName, got)
+			}
+			if got := p.ManagedPrefsUserPlist("alice"); got != "" {
+				t.Errorf("%s ManagedPrefsUserPlist = %q, want empty", osName, got)
+			}
+			if got := p.OrgPluginsDir(); got != "" {
+				t.Errorf("%s OrgPluginsDir = %q, want empty", osName, got)
+			}
+			if got := p.ClaudeAppPath(); got != "" {
+				t.Errorf("%s ClaudeAppPath = %q, want empty", osName, got)
+			}
+			if got := p.UserSessionsDir(); got != "" {
+				t.Errorf("%s UserSessionsDir = %q, want empty", osName, got)
+			}
+			if got := p.WindowsRegistryPath(); got != "" {
+				t.Errorf("%s WindowsRegistryPath = %q, want empty", osName, got)
+			}
+			if got := p.LaunchAgentDir(); got != "" {
+				t.Errorf("%s LaunchAgentDir = %q, want empty", osName, got)
+			}
+		})
+	}
+}
+
+// TestForOS_ReturnsInterface guards against accidental nil returns from
+// ForOS. A nil Provider would crash callers at the first method call.
+func TestForOS_ReturnsInterface(t *testing.T) {
+	for _, osName := range []string{"darwin", "windows", "linux", "unknown"} {
+		t.Run(osName, func(t *testing.T) {
+			if p := ForOS(osName); p == nil {
+				t.Fatalf("ForOS(%q) returned nil Provider", osName)
+			}
+		})
+	}
+}
+
+// TestDefault_ReturnsProvider is a smoke test that confirms the build-tagged
+// Default() dispatches and returns a non-nil Provider on whichever host
+// runs the test. Per-platform value assertions live in the ForOS tests.
+func TestDefault_ReturnsProvider(t *testing.T) {
+	if p := Default(); p == nil {
+		t.Fatal("Default() returned nil")
+	}
+}

--- a/internal/paths/paths_windows.go
+++ b/internal/paths/paths_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package paths
+
+// Default returns the Provider for the current operating system (windows).
+func Default() Provider {
+	return windowsProvider{}
+}


### PR DESCRIPTION
## Summary

Platform-aware path resolver per \`specs/paths.md\`.

- Provider interface with all 7 methods specced
- Concrete darwin/windows/linux providers in paths.go (no build tags) so ForOS() simulates any OS
- Build-tagged Default() in paths_darwin.go / paths_windows.go / paths_other.go
- Injectable home resolver for deterministic tests

## Sparring trail

\`codex:rescue\` — 1 MUST-FIX, 0 SHOULD-FIX:

- darwinProvider.UserSessionsDir() stripped trailing slashes from home. When HOME=\"/\", trim produced \"\" and path.Join produced a relative path, violating spec. Fixed by removing the trim; added regression test case.

## Test plan

- [x] go test green locally + -race
- [x] Cross-build (darwin/windows/linux × amd64+arm64)
- [x] verify.sh task-02 PASS
- [x] Sparring-approved
- [ ] CI green

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)