### PR TITLE
chore(release): skip brew upload when HOMEBREW_TAP_GITHUB_TOKEN unset

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,8 +65,13 @@ release:
     **Not affiliated with Anthropic.** This project is an independent tool built on
     public reverse-engineering of the Claude Desktop application.
 
+# Homebrew tap push is gated by HOMEBREW_TAP_GITHUB_TOKEN. When the secret
+# is unset (e.g. first-time releases, or open-source forks), `skip_upload:
+# auto` makes GoReleaser emit the formula locally (in dist/) but skip the
+# push, letting GitHub Release + binaries still ship.
 brews:
   - name: cowork-mdm
+    skip_upload: '{{ if eq .Env.HOMEBREW_TAP_GITHUB_TOKEN "" }}true{{ else }}false{{ end }}'
     repository:
       owner: krislavten
       name: homebrew-tap


### PR DESCRIPTION
Unblocks v0.1.0 release. GoReleaser was failing entire workflow when the brew push hit 401. Template gate lets the rest of the release ship without the secret.