### PR TITLE
task-03: add internal/profile core + mobileconfig/plist encoders + decoders + templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Preserve LF line endings on files that tests compare byte-exact.
+# Without this, git on Windows converts to CRLF at checkout and the
+# golden tests fail there.
+*.golden.* binary
+*.mobileconfig text eol=lf
+*.plist text eol=lf

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/krislavten/cowork-mdm
 
 go 1.23
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/profile/decode.go
+++ b/internal/profile/decode.go
@@ -313,10 +313,14 @@ func parseValue(dec *xml.Decoder, start xml.StartElement) (any, error) {
 		}
 		return f, nil
 	case "true":
-		dec.Skip()
+		if err := dec.Skip(); err != nil {
+			return nil, err
+		}
 		return true, nil
 	case "false":
-		dec.Skip()
+		if err := dec.Skip(); err != nil {
+			return nil, err
+		}
 		return false, nil
 	case "array":
 		var arr []any

--- a/internal/profile/decode.go
+++ b/internal/profile/decode.go
@@ -1,0 +1,377 @@
+package profile
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+// Detect inspects data and returns the likely format: "mobileconfig",
+// "plist", "reg", or "" (unknown).
+//
+// mobileconfig vs plist: both are plist XML, but mobileconfig's top-level
+// dict has a PayloadContent array. We check for that marker.
+func Detect(data []byte) string {
+	// reg files begin with "Windows Registry Editor" magic header.
+	if bytes.HasPrefix(data, []byte("Windows Registry Editor")) {
+		return "reg"
+	}
+	if bytes.Contains(data, []byte("<!DOCTYPE plist")) || bytes.Contains(data, []byte("<plist")) {
+		if bytes.Contains(data, []byte("PayloadContent")) {
+			return "mobileconfig"
+		}
+		return "plist"
+	}
+	return ""
+}
+
+// orderedDict preserves insertion order. Used by decoders so `Profile` sees
+// keys in the order they appeared in the source plist — the spec requires
+// round-trip semantic equivalence including order.
+type orderedDict struct {
+	entries []orderedEntry
+	index   map[string]int
+}
+
+type orderedEntry struct {
+	Key   string
+	Value any
+}
+
+func (d *orderedDict) set(key string, value any) {
+	if d.index == nil {
+		d.index = make(map[string]int)
+	}
+	if i, ok := d.index[key]; ok {
+		d.entries[i].Value = value
+		return
+	}
+	d.entries = append(d.entries, orderedEntry{Key: key, Value: value})
+	d.index[key] = len(d.entries) - 1
+}
+
+func (d *orderedDict) get(key string) (any, bool) {
+	i, ok := d.index[key]
+	if !ok {
+		return nil, false
+	}
+	return d.entries[i].Value, true
+}
+
+// DecodeMobileConfig parses an Apple Configuration Profile and returns the
+// embedded com.anthropic.claudefordesktop payload as a Profile. Unknown keys
+// are preserved on the Profile and reported in the DecodeReport.
+func DecodeMobileConfig(data []byte) (*Profile, DecodeReport, error) {
+	dict, err := parsePlistRootDict(data)
+	if err != nil {
+		return nil, DecodeReport{}, fmt.Errorf("decode mobileconfig: %w", err)
+	}
+	content, ok := dict.get("PayloadContent")
+	if !ok {
+		return nil, DecodeReport{}, fmt.Errorf("decode mobileconfig: no PayloadContent array")
+	}
+	arr, ok := content.([]any)
+	if !ok {
+		return nil, DecodeReport{}, fmt.Errorf("decode mobileconfig: PayloadContent is %T, want array", content)
+	}
+
+	var payload *orderedDict
+	for _, item := range arr {
+		od, ok := item.(*orderedDict)
+		if !ok {
+			continue
+		}
+		if t, _ := od.get("PayloadType"); t == "com.anthropic.claudefordesktop" {
+			payload = od
+			break
+		}
+	}
+	if payload == nil {
+		return nil, DecodeReport{}, fmt.Errorf("decode mobileconfig: no com.anthropic.claudefordesktop payload")
+	}
+
+	name, _ := firstString(payload, "PayloadDisplayName")
+	if name == "" {
+		name, _ = firstString(dict, "PayloadDisplayName")
+	}
+	p := New(name)
+	report := DecodeReport{}
+	for _, e := range payload.entries {
+		if isPayloadMetadataKey(e.Key) {
+			continue
+		}
+		assignDecodedValue(p, &report, e.Key, e.Value)
+	}
+	return p, report, nil
+}
+
+// DecodePlist parses the bare com.anthropic.claudefordesktop.plist body.
+func DecodePlist(data []byte) (*Profile, DecodeReport, error) {
+	dict, err := parsePlistRootDict(data)
+	if err != nil {
+		return nil, DecodeReport{}, fmt.Errorf("decode plist: %w", err)
+	}
+	p := New("")
+	report := DecodeReport{}
+	for _, e := range dict.entries {
+		assignDecodedValue(p, &report, e.Key, e.Value)
+	}
+	return p, report, nil
+}
+
+// firstString is a small type-asserting helper used by decoders.
+func firstString(d *orderedDict, key string) (string, bool) {
+	v, ok := d.get(key)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// DecodeReg is not yet implemented in v0.1; reserved for task-06.
+func DecodeReg(_ []byte) (*Profile, DecodeReport, error) {
+	return nil, DecodeReport{}, fmt.Errorf("decode .reg: not implemented (v0.3)")
+}
+
+// assignDecodedValue maps a raw plist-parsed value onto the profile,
+// converting stringArray / jsonString types from their JSON-in-string
+// encoding back to typed Go values. Unknown keys and type-mismatches are
+// recorded on the report; a schema type mismatch does NOT fail decoding
+// (caller's Validate() surfaces it).
+func assignDecodedValue(p *Profile, report *DecodeReport, key string, value any) {
+	s := schema.Load()
+	k := s.Find(key)
+	if k == nil {
+		p.AttachUnknownKey(key, fmt.Sprintf("%v", value))
+		report.UnknownKeys = append(report.UnknownKeys, UnknownKey{Key: key, RawValue: fmt.Sprintf("%v", value)})
+		// still carry the raw value in the profile for round-trip fidelity
+		p.SetRaw(key, value)
+		return
+	}
+	switch k.Type {
+	case schema.TypeStringArray:
+		// stored as JSON-in-string
+		if s, ok := value.(string); ok {
+			arr, err := parseJSONStringArray(s)
+			if err != nil {
+				report.Warnings = append(report.Warnings,
+					fmt.Sprintf("%s: stringArray value did not parse as JSON array: %s", key, err))
+				p.SetRaw(key, value)
+				return
+			}
+			p.SetRaw(key, arr)
+			return
+		}
+		p.SetRaw(key, value)
+	case schema.TypeJSONString:
+		// keep as string; callers decide whether to parse further
+		if s, ok := value.(string); ok {
+			p.SetRaw(key, s)
+			return
+		}
+		p.SetRaw(key, value)
+	default:
+		p.SetRaw(key, value)
+	}
+}
+
+func isPayloadMetadataKey(key string) bool {
+	switch key {
+	case "PayloadType", "PayloadIdentifier", "PayloadUUID",
+		"PayloadDisplayName", "PayloadVersion", "PayloadOrganization",
+		"PayloadDescription", "PayloadScope", "PayloadEnabled":
+		return true
+	}
+	return false
+}
+
+// parseJSONStringArray parses a raw JSON array-of-strings stored in a plist
+// <string> element. Encoders always produce well-formed JSON; this decoder
+// requires the same — no fallback tolerance for malformed input.
+func parseJSONStringArray(s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
+		return nil, fmt.Errorf("not an array literal")
+	}
+	var arr []string
+	if err := jsonUnmarshal(s, &arr); err != nil {
+		return nil, err
+	}
+	return arr, nil
+}
+
+// parsePlistRootDict uses encoding/xml with a tolerant handler that emits a
+// Go value tree mirroring the plist structure. It only supports the subset
+// of plist we generate: dict / array / string / integer / true / false /
+// real / data. Keys carried in <key>...</key> siblings of dict children.
+// Returns an ordered dict so consumers (Profile) see keys in source order.
+func parsePlistRootDict(data []byte) (*orderedDict, error) {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.Strict = false // allow XHTML-ish tolerances
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		se, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if se.Name.Local != "plist" {
+			continue
+		}
+		// first child should be the root <dict>
+		for {
+			tok, err := dec.Token()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			if se2, ok := tok.(xml.StartElement); ok {
+				if se2.Name.Local != "dict" {
+					return nil, fmt.Errorf("expected root <dict>, got <%s>", se2.Name.Local)
+				}
+				return parseDict(dec)
+			}
+		}
+	}
+	return nil, fmt.Errorf("no <plist> root element found")
+}
+
+func parseDict(dec *xml.Decoder) (*orderedDict, error) {
+	out := &orderedDict{}
+	var pendingKey string
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "key":
+				s, err := readCharData(dec)
+				if err != nil {
+					return nil, err
+				}
+				pendingKey = s
+			default:
+				val, err := parseValue(dec, t)
+				if err != nil {
+					return nil, err
+				}
+				if pendingKey == "" {
+					return nil, fmt.Errorf("value <%s> with no preceding <key>", t.Name.Local)
+				}
+				out.set(pendingKey, val)
+				pendingKey = ""
+			}
+		case xml.EndElement:
+			if t.Name.Local == "dict" {
+				return out, nil
+			}
+		}
+	}
+}
+
+func parseValue(dec *xml.Decoder, start xml.StartElement) (any, error) {
+	switch start.Name.Local {
+	case "string":
+		return readCharData(dec)
+	case "integer":
+		s, err := readCharData(dec)
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return n, nil
+	case "real":
+		s, err := readCharData(dec)
+		if err != nil {
+			return nil, err
+		}
+		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	case "true":
+		dec.Skip()
+		return true, nil
+	case "false":
+		dec.Skip()
+		return false, nil
+	case "array":
+		var arr []any
+		for {
+			tok, err := dec.Token()
+			if err != nil {
+				return nil, err
+			}
+			switch tt := tok.(type) {
+			case xml.StartElement:
+				v, err := parseValue(dec, tt)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, v)
+			case xml.EndElement:
+				if tt.Name.Local == "array" {
+					return arr, nil
+				}
+			}
+		}
+	case "dict":
+		return parseDict(dec)
+	case "data":
+		// preserve as string; we don't currently emit data values but decoders
+		// should tolerate them
+		return readCharData(dec)
+	default:
+		if err := dec.Skip(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+}
+
+// readCharData consumes CharData until the matching end element and returns
+// the concatenated text. Safe against empty elements (<string/>).
+func readCharData(dec *xml.Decoder) (string, error) {
+	var b strings.Builder
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return "", err
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			b.Write(t)
+		case xml.EndElement:
+			return b.String(), nil
+		}
+	}
+}
+
+// jsonUnmarshal is declared as a variable so tests can swap in a faster
+// alternative if necessary. Defaults to encoding/json.Unmarshal.
+var jsonUnmarshal = func(s string, v any) error {
+	return jsonUnmarshalImpl(s, v)
+}

--- a/internal/profile/decode_test.go
+++ b/internal/profile/decode_test.go
@@ -1,0 +1,173 @@
+package profile
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDetectFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want string
+	}{
+		{"mobileconfig", `<?xml version="1.0"?>
+<!DOCTYPE plist PUBLIC ...>
+<plist><dict>
+<key>PayloadContent</key><array></array>
+</dict></plist>`, "mobileconfig"},
+		{"plain plist", `<?xml version="1.0"?>
+<!DOCTYPE plist PUBLIC ...>
+<plist><dict>
+<key>inferenceProvider</key><string>bedrock</string>
+</dict></plist>`, "plist"},
+		{"reg file", "Windows Registry Editor Version 5.00\r\n\r\n[HKLM\\SOFTWARE\\Policies\\Claude]", "reg"},
+		{"unknown", "<html>not a plist</html>", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Detect([]byte(c.data)); got != c.want {
+				t.Errorf("Detect = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDecodePlist_KnownKeys(t *testing.T) {
+	src := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>inferenceProvider</key>
+	<string>bedrock</string>
+	<key>disableDeploymentModeChooser</key>
+	<true/>
+	<key>inferenceBedrockRegion</key>
+	<string>us-west-2</string>
+	<key>coworkEgressAllowedHosts</key>
+	<string>["*"]</string>
+</dict>
+</plist>`
+	p, rep, err := DecodePlist([]byte(src))
+	if err != nil {
+		t.Fatalf("DecodePlist: %v", err)
+	}
+	if len(rep.UnknownKeys) != 0 {
+		t.Errorf("unexpected unknown keys: %v", rep.UnknownKeys)
+	}
+	if v, _ := p.Get("inferenceProvider"); v != "bedrock" {
+		t.Errorf("inferenceProvider = %v", v)
+	}
+	if v, _ := p.Get("disableDeploymentModeChooser"); v != true {
+		t.Errorf("disableDeploymentModeChooser = %v (%T)", v, v)
+	}
+	// stringArray round-tripped back to []string
+	v, _ := p.Get("coworkEgressAllowedHosts")
+	arr, ok := v.([]string)
+	if !ok {
+		t.Fatalf("coworkEgressAllowedHosts type = %T, want []string", v)
+	}
+	if !reflect.DeepEqual(arr, []string{"*"}) {
+		t.Errorf("coworkEgressAllowedHosts = %v, want [*]", arr)
+	}
+}
+
+func TestDecodePlist_UnknownKeyPreserved(t *testing.T) {
+	src := `<?xml version="1.0"?>
+<plist version="1.0">
+<dict>
+	<key>inferenceProvider</key>
+	<string>bedrock</string>
+	<key>notARealKey</key>
+	<string>garbage</string>
+</dict>
+</plist>`
+	p, rep, err := DecodePlist([]byte(src))
+	if err != nil {
+		t.Fatalf("DecodePlist: %v", err)
+	}
+	if len(rep.UnknownKeys) != 1 || rep.UnknownKeys[0].Key != "notARealKey" {
+		t.Errorf("UnknownKeys = %v, want [notARealKey]", rep.UnknownKeys)
+	}
+	// The value is still on the profile for round-trip fidelity
+	if _, ok := p.Get("notARealKey"); !ok {
+		t.Error("unknown key missing from Profile.Get")
+	}
+	// Validate surfaces the unknown key
+	err = p.Validate()
+	if err == nil {
+		t.Error("Validate should flag unknown key")
+	}
+}
+
+func TestDecodeMobileConfig(t *testing.T) {
+	src := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key><string>com.anthropic.claudefordesktop</string>
+			<key>PayloadIdentifier</key><string>com.yuanli.test.settings</string>
+			<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000000</string>
+			<key>PayloadDisplayName</key><string>yuanli-test</string>
+			<key>PayloadVersion</key><integer>1</integer>
+			<key>inferenceProvider</key><string>bedrock</string>
+			<key>inferenceBedrockRegion</key><string>us-west-2</string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key><string>yuanli-test</string>
+	<key>PayloadType</key><string>Configuration</string>
+	<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000001</string>
+	<key>PayloadVersion</key><integer>1</integer>
+</dict>
+</plist>`
+	p, _, err := DecodeMobileConfig([]byte(src))
+	if err != nil {
+		t.Fatalf("DecodeMobileConfig: %v", err)
+	}
+	if p.Name != "yuanli-test" {
+		t.Errorf("Name = %q, want yuanli-test", p.Name)
+	}
+	if v, _ := p.Get("inferenceProvider"); v != "bedrock" {
+		t.Errorf("inferenceProvider = %v", v)
+	}
+	// Payload metadata keys should NOT leak into the profile
+	if _, ok := p.Get("PayloadType"); ok {
+		t.Errorf("PayloadType should be stripped from decoded profile")
+	}
+}
+
+func TestRoundtrip_SemanticEquivalence(t *testing.T) {
+	// Encode a profile to plist, decode it back, re-encode, confirm
+	// semantic equivalence (same MDM values, same order). We don't
+	// compare byte-identical because there's nothing non-deterministic
+	// in EncodePlist currently — but the test asserts semantic behavior
+	// anyway, to catch any encoder drift.
+	orig := New("rt-test")
+	_ = orig.Set("inferenceProvider", "bedrock")
+	_ = orig.Set("inferenceBedrockRegion", "us-west-2")
+	_ = orig.Set("disableDeploymentModeChooser", true)
+	_ = orig.Set("coworkEgressAllowedHosts", []string{"example.com", "*.internal"})
+
+	encoded, err := EncodePlist(orig)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, _, err := DecodePlist(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Len() != orig.Len() {
+		t.Fatalf("decoded Len = %d, orig Len = %d", decoded.Len(), orig.Len())
+	}
+	for _, k := range orig.Keys() {
+		origV, _ := orig.Get(k)
+		decV, _ := decoded.Get(k)
+		if !reflect.DeepEqual(origV, decV) {
+			t.Errorf("roundtrip differs at %s: orig=%v (%T) vs decoded=%v (%T)",
+				k, origV, origV, decV, decV)
+		}
+	}
+}

--- a/internal/profile/encode_mobileconfig.go
+++ b/internal/profile/encode_mobileconfig.go
@@ -1,0 +1,293 @@
+package profile
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+// MobileConfigOpts controls how a profile is wrapped into an Apple
+// Configuration Profile (.mobileconfig). PayloadUUIDs are randomized unless
+// explicitly set, which is how Apple expects it — UUIDs should change across
+// exports to avoid MDM collisions. Tests supply fixed values.
+type MobileConfigOpts struct {
+	PayloadIdentifier string // default "com.yuanli.cowork-mdm.<slug-of-name>"
+
+	// PayloadUUID is the inner payload's UUID (the one for the
+	// com.anthropic.claudefordesktop payload entry). This matches the
+	// spec's naming — if you only set one UUID this is the one you'd
+	// usually want to pin.
+	PayloadUUID string // default random v4-shaped
+
+	// ConfigurationPayloadUUID is the outer Configuration envelope's UUID.
+	// Usually fine to leave randomized; pin only for golden-file tests.
+	ConfigurationPayloadUUID string // default random v4-shaped
+
+	PayloadOrganization string // default empty
+	PayloadScope        string // "System" (default) | "User"
+}
+
+// EncodeMobileConfig wraps the profile's MDM key/value pairs in the standard
+// Apple Configuration Profile XML structure.
+//
+// Critical encoding rule (mirrors Claude.app's jee() reader): arrays and
+// jsonString values go inside <string> elements as JSON text, NOT as <array>.
+// Claude.app calls JSON.parse on the string — a native plist array fails.
+func EncodeMobileConfig(p *Profile, opts MobileConfigOpts) ([]byte, error) {
+	if opts.PayloadIdentifier == "" {
+		opts.PayloadIdentifier = "com.yuanli.cowork-mdm." + slugify(p.Name)
+	}
+	if opts.ConfigurationPayloadUUID == "" {
+		opts.ConfigurationPayloadUUID = randomUUID()
+	}
+	if opts.PayloadUUID == "" {
+		opts.PayloadUUID = randomUUID()
+	}
+	if opts.PayloadScope == "" {
+		opts.PayloadScope = "System"
+	}
+
+	// Validate up-front so callers never receive a mobileconfig with known-
+	// bad MDM values. This includes schema-known unknown-key errors.
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("profile validation failed: %w", err)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(plistHeader)
+	buf.WriteString("<plist version=\"1.0\">\n")
+	buf.WriteString("<dict>\n")
+
+	fmt.Fprintf(&buf, "\t<key>PayloadContent</key>\n")
+	fmt.Fprintln(&buf, "\t<array>")
+	fmt.Fprintln(&buf, "\t\t<dict>")
+	writeKV(&buf, "\t\t\t", "PayloadType", "com.anthropic.claudefordesktop")
+	writeKV(&buf, "\t\t\t", "PayloadIdentifier", opts.PayloadIdentifier+".settings")
+	writeKV(&buf, "\t\t\t", "PayloadUUID", opts.PayloadUUID)
+	writeKV(&buf, "\t\t\t", "PayloadDisplayName", p.Name)
+	fmt.Fprintln(&buf, "\t\t\t<key>PayloadVersion</key>")
+	fmt.Fprintln(&buf, "\t\t\t<integer>1</integer>")
+	if err := writeProfileEntries(&buf, p, "\t\t\t"); err != nil {
+		return nil, fmt.Errorf("profile encode failed: %w", err)
+	}
+	fmt.Fprintln(&buf, "\t\t</dict>")
+	fmt.Fprintln(&buf, "\t</array>")
+	writeKV(&buf, "\t", "PayloadDisplayName", p.Name)
+	writeKV(&buf, "\t", "PayloadIdentifier", opts.PayloadIdentifier)
+	if opts.PayloadOrganization != "" {
+		writeKV(&buf, "\t", "PayloadOrganization", opts.PayloadOrganization)
+	}
+	writeKV(&buf, "\t", "PayloadType", "Configuration")
+	writeKV(&buf, "\t", "PayloadUUID", opts.ConfigurationPayloadUUID)
+	fmt.Fprintln(&buf, "\t<key>PayloadVersion</key>")
+	fmt.Fprintln(&buf, "\t<integer>1</integer>")
+	writeKV(&buf, "\t", "PayloadScope", opts.PayloadScope)
+	buf.WriteString("</dict>\n")
+	buf.WriteString("</plist>\n")
+	return buf.Bytes(), nil
+}
+
+const plistHeader = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+`
+
+// writeProfileEntries emits <key>...</key><value/> pairs for every entry in
+// the profile using the plist type mapping specified in specs/profile.md.
+func writeProfileEntries(w io.Writer, p *Profile, indent string) error {
+	s := schema.Load()
+	for _, e := range p.entries {
+		k := s.Find(e.Key)
+		if k == nil {
+			return &UnknownKeyError{Key: e.Key}
+		}
+		if err := writePlistValue(w, indent, e.Key, k.Type, e.Value); err != nil {
+			return fmt.Errorf("%s: %w", e.Key, err)
+		}
+	}
+	return nil
+}
+
+// writePlistValue writes one <key>+<value> pair per the type mapping.
+func writePlistValue(w io.Writer, indent, key string, t schema.Type, value any) error {
+	fmt.Fprintf(w, "%s<key>%s</key>\n", indent, escapeXML(key))
+
+	switch t {
+	case schema.TypeBoolean:
+		b, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("boolean value expected, got %T", value)
+		}
+		if b {
+			fmt.Fprintf(w, "%s<true/>\n", indent)
+		} else {
+			fmt.Fprintf(w, "%s<false/>\n", indent)
+		}
+
+	case schema.TypeInteger:
+		var n int64
+		switch v := value.(type) {
+		case int:
+			n = int64(v)
+		case int64:
+			n = v
+		case int32:
+			n = int64(v)
+		case float64:
+			if v != float64(int64(v)) {
+				return fmt.Errorf("integer value expected, got non-whole float %v", v)
+			}
+			n = int64(v)
+		default:
+			return fmt.Errorf("integer value expected, got %T", value)
+		}
+		fmt.Fprintf(w, "%s<integer>%d</integer>\n", indent, n)
+
+	case schema.TypeString, schema.TypeURL, schema.TypeEnum:
+		s, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("string value expected, got %T", value)
+		}
+		fmt.Fprintf(w, "%s<string>%s</string>\n", indent, escapeXML(s))
+
+	case schema.TypeStringArray:
+		// Arrays go as JSON strings per the managed-prefs reader contract.
+		arr, err := coerceStringArray(value)
+		if err != nil {
+			return err
+		}
+		b, err := json.Marshal(arr)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s<string>%s</string>\n", indent, escapeXML(string(b)))
+
+	case schema.TypeJSONString:
+		// jsonString values are stored as a string; accept either a raw JSON
+		// string or a pre-unmarshaled map/slice and marshal it deterministically.
+		s, err := coerceJSONString(value)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s<string>%s</string>\n", indent, escapeXML(s))
+
+	default:
+		return fmt.Errorf("unsupported schema type %q", t)
+	}
+	return nil
+}
+
+func coerceStringArray(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("stringArray element %d is %T, want string", i, item)
+			}
+			out[i] = s
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("stringArray value expected, got %T", value)
+	}
+}
+
+func coerceJSONString(value any) (string, error) {
+	if s, ok := value.(string); ok {
+		// Validate it parses as JSON so we don't smuggle garbage through.
+		var any any
+		if err := json.Unmarshal([]byte(s), &any); err != nil {
+			return "", fmt.Errorf("jsonString is not valid JSON: %w", err)
+		}
+		return s, nil
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("cannot marshal jsonString value: %w", err)
+	}
+	return string(b), nil
+}
+
+func writeKV(w io.Writer, indent, key, value string) {
+	fmt.Fprintf(w, "%s<key>%s</key>\n", indent, escapeXML(key))
+	fmt.Fprintf(w, "%s<string>%s</string>\n", indent, escapeXML(value))
+}
+
+// escapeXML escapes the five reserved XML characters. Values may contain
+// characters that matter inside plist text content — we can't rely on
+// encoding/xml because we emit hand-formatted plist for golden-file
+// stability.
+func escapeXML(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '&':
+			b.WriteString("&amp;")
+		case '<':
+			b.WriteString("&lt;")
+		case '>':
+			b.WriteString("&gt;")
+		case '"':
+			b.WriteString("&quot;")
+		case '\'':
+			b.WriteString("&apos;")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// slugify produces a simple ASCII-slug for use in PayloadIdentifier suffixes.
+func slugify(s string) string {
+	if s == "" {
+		return "profile"
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + 32)
+		case r == '-', r == '_':
+			b.WriteRune(r)
+		case r == ' ', r == '.':
+			b.WriteByte('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "profile"
+	}
+	return out
+}
+
+// randomUUID returns a v4-shaped UUID string (random bytes formatted as
+// xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx). Apple's tools don't verify the
+// RFC-4122 variant bits but we set them anyway for wellformedness.
+//
+// If crypto/rand fails (OS denying entropy — very rare), we return a
+// documented all-zeros sentinel so output is still well-formed XML. Callers
+// that care should pass explicit UUIDs via MobileConfigOpts.
+func randomUUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "00000000-0000-4000-8000-000000000000"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	s := hex.EncodeToString(b[:])
+	return strings.ToUpper(s[0:8] + "-" + s[8:12] + "-" + s[12:16] + "-" + s[16:20] + "-" + s[20:32])
+}

--- a/internal/profile/encode_mobileconfig_test.go
+++ b/internal/profile/encode_mobileconfig_test.go
@@ -1,0 +1,182 @@
+package profile
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// buildBedrockProfile returns a profile resembling the handcrafted plists
+// we used to write for real-world deployments — provider + region + profile
+// + aws dir + model list + a minimal MCP server with tool policy.
+func buildBedrockProfile(t *testing.T) *Profile {
+	t.Helper()
+	p := New("cowork-mdm-test")
+	set := func(k string, v any) {
+		if err := p.Set(k, v); err != nil {
+			t.Fatalf("Set %s: %v", k, err)
+		}
+	}
+	set("inferenceProvider", "bedrock")
+	set("disableDeploymentModeChooser", true)
+	set("inferenceBedrockRegion", "us-west-2")
+	set("inferenceBedrockProfile", "default")
+	set("inferenceBedrockAwsDir", "/Users/testuser/.aws")
+	set("coworkEgressAllowedHosts", []string{"*"})
+	set("inferenceModels", []string{
+		"arn:aws:bedrock:us-west-2:111111111111:application-inference-profile/AAAAAAAAAAAA",
+		"arn:aws:bedrock:us-west-2:111111111111:application-inference-profile/BBBBBBBBBBBB[1m]",
+	})
+	set("managedMcpServers", `[{"name":"example-mcp","url":"https://mcp.example.com/stream","transport":"http","toolPolicy":{"exampleTool":"allow"}}]`)
+	return p
+}
+
+func TestEncodeMobileConfig_StructuralInvariants(t *testing.T) {
+	p := buildBedrockProfile(t)
+	out, err := EncodeMobileConfig(p, MobileConfigOpts{
+		ConfigurationPayloadUUID: "00000000-0000-4000-8000-000000000000",
+		PayloadUUID:              "11111111-1111-4111-8111-111111111111",
+	})
+	if err != nil {
+		t.Fatalf("EncodeMobileConfig: %v", err)
+	}
+	s := string(out)
+
+	// mobileconfig envelope
+	for _, want := range []string{
+		"<!DOCTYPE plist", "<plist version=\"1.0\">",
+		"<key>PayloadContent</key>", "<key>PayloadType</key>",
+		"<string>Configuration</string>",
+		"<string>com.anthropic.claudefordesktop</string>",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing expected fragment: %s", want)
+		}
+	}
+
+	// Per-key type mapping invariants
+	if !strings.Contains(s, "<key>inferenceProvider</key>\n\t\t\t<string>bedrock</string>") {
+		t.Errorf("enum value not emitted as <string>: see\n%s", s)
+	}
+	if !strings.Contains(s, "<key>disableDeploymentModeChooser</key>\n\t\t\t<true/>") {
+		t.Errorf("boolean true not emitted as <true/>")
+	}
+	// stringArray becomes JSON-in-string — must NOT be a <array> element.
+	if strings.Contains(s, "<key>coworkEgressAllowedHosts</key>\n\t\t\t<array>") {
+		t.Errorf("stringArray should be encoded as <string>, not <array>")
+	}
+	if !strings.Contains(s, `<key>coworkEgressAllowedHosts</key>`) {
+		t.Errorf("egress key missing")
+	}
+	if !strings.Contains(s, `[&quot;*&quot;]`) {
+		t.Errorf(`egress JSON quote escaping wrong — expected &quot;*&quot; in XML, got:\n%s`, s)
+	}
+	// jsonString (managedMcpServers) preserves its raw JSON verbatim
+	if !strings.Contains(s, "example-mcp") {
+		t.Errorf("managedMcpServers content missing")
+	}
+
+	// The outer payload UUID we requested
+	if !strings.Contains(s, "00000000-0000-4000-8000-000000000000") {
+		t.Errorf("requested outer UUID not honored")
+	}
+
+	// PayloadContent array has exactly one inner dict (the claude one)
+	if strings.Count(s, "<key>PayloadType</key>") != 2 {
+		t.Errorf("expected PayloadType to appear twice (inner+outer), got %d",
+			strings.Count(s, "<key>PayloadType</key>"))
+	}
+}
+
+// TestEncodeMobileConfig_PlutilLint confirms the output is accepted by
+// macOS's plutil -lint. Runs only on darwin where plutil is present.
+func TestEncodeMobileConfig_PlutilLint(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skipf("plutil only on darwin, got %s", runtime.GOOS)
+	}
+	if _, err := exec.LookPath("plutil"); err != nil {
+		t.Skip("plutil not in PATH")
+	}
+	p := buildBedrockProfile(t)
+	out, err := EncodeMobileConfig(p, MobileConfigOpts{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp := t.TempDir() + "/test.mobileconfig"
+	if err := writeFile(tmp, out); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	cmd := exec.Command("plutil", "-lint", tmp)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("plutil -lint failed: %v\noutput: %s\nfile:\n%s",
+			err, string(output), string(out))
+	}
+}
+
+func TestEncodePlist_StructuralInvariants(t *testing.T) {
+	p := buildBedrockProfile(t)
+	out, err := EncodePlist(p)
+	if err != nil {
+		t.Fatalf("EncodePlist: %v", err)
+	}
+	s := string(out)
+
+	// plist body only, no mobileconfig wrapper
+	if strings.Contains(s, "PayloadContent") || strings.Contains(s, "PayloadType") {
+		t.Errorf("EncodePlist must not emit Apple payload wrapper keys")
+	}
+	// but it must still have every MDM key
+	for _, want := range []string{
+		"<key>inferenceProvider</key>",
+		"<key>inferenceBedrockRegion</key>",
+		"<key>inferenceModels</key>",
+		"<key>managedMcpServers</key>",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %s", want)
+		}
+	}
+}
+
+func TestEncodePlist_PlutilLint(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skipf("plutil only on darwin, got %s", runtime.GOOS)
+	}
+	if _, err := exec.LookPath("plutil"); err != nil {
+		t.Skip("plutil not in PATH")
+	}
+	p := buildBedrockProfile(t)
+	out, err := EncodePlist(p)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp := t.TempDir() + "/test.plist"
+	if err := writeFile(tmp, out); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	cmd := exec.Command("plutil", "-lint", tmp)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("plutil -lint failed: %v\noutput: %s\nfile:\n%s",
+			err, string(output), string(out))
+	}
+}
+
+func TestEncodeMobileConfig_GeneratesDifferentUUIDsEachCall(t *testing.T) {
+	p := buildBedrockProfile(t)
+	a, err := EncodeMobileConfig(p, MobileConfigOpts{})
+	if err != nil {
+		t.Fatalf("encode a: %v", err)
+	}
+	b, err := EncodeMobileConfig(p, MobileConfigOpts{})
+	if err != nil {
+		t.Fatalf("encode b: %v", err)
+	}
+	// Deliberately: outputs should differ only in PayloadUUID fields.
+	// Simpler assertion: not byte-identical.
+	if string(a) == string(b) {
+		t.Error("two EncodeMobileConfig calls with default opts produced byte-identical output; expected UUIDs to differ")
+	}
+}

--- a/internal/profile/encode_plist.go
+++ b/internal/profile/encode_plist.go
@@ -1,0 +1,30 @@
+package profile
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// EncodePlist emits the bare com.anthropic.claudefordesktop.plist body with
+// no Configuration wrapper. This is the format that actually lives at
+//
+//	/Library/Managed Preferences/com.anthropic.claudefordesktop.plist
+//
+// It's the same per-key type mapping as EncodeMobileConfig, just without
+// the Apple Configuration Profile envelope. Use this when writing directly
+// to the managed-prefs path (i.e. for `profile apply`), not for MDM delivery.
+func EncodePlist(p *Profile) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(plistHeader)
+	buf.WriteString("<plist version=\"1.0\">\n")
+	buf.WriteString("<dict>\n")
+	if err := writeProfileEntries(&buf, p, "\t"); err != nil {
+		return nil, err
+	}
+	buf.WriteString("</dict>\n")
+	buf.WriteString("</plist>\n")
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("profile validation failed: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/profile/golden_gen_test.go
+++ b/internal/profile/golden_gen_test.go
@@ -1,0 +1,34 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Not a real test — writes the golden file when run with -run GoldenGen.
+// Usage: go test -run TestGoldenGen ./internal/profile/...
+// Commit the resulting file; delete this file after the golden is stable,
+// or keep it to make regeneration a one-liner.
+func TestGoldenGen(t *testing.T) {
+	if os.Getenv("GEN_GOLDEN") != "1" {
+		t.Skip("set GEN_GOLDEN=1 to (re)generate testdata/bedrock-basic.golden.mobileconfig")
+	}
+	p, err := LoadTemplate("bedrock-basic")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	out, err := EncodeMobileConfig(p, MobileConfigOpts{
+		ConfigurationPayloadUUID: "00000000-0000-4000-8000-000000000000",
+		PayloadUUID:              "11111111-1111-4111-8111-111111111111",
+		PayloadIdentifier:        "com.example.cowork-mdm.bedrock-basic",
+	})
+	if err != nil {
+		t.Fatalf("EncodeMobileConfig: %v", err)
+	}
+	path := filepath.Join("testdata", "bedrock-basic.golden.mobileconfig")
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Logf("wrote %s (%d bytes)", path, len(out))
+}

--- a/internal/profile/golden_test.go
+++ b/internal/profile/golden_test.go
@@ -30,6 +30,12 @@ func TestEncodeMobileConfig_GoldenBedrockBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeMobileConfig: %v", err)
 	}
+	// Normalize line endings: on Windows runners, git may check out the
+	// golden with CRLF even though we ship it as LF, and our encoder
+	// always emits LF. Compare LF-normalized so CI stays green without
+	// relying on the runner's core.autocrlf config.
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
+	got = bytes.ReplaceAll(got, []byte("\r\n"), []byte("\n"))
 	if !bytes.Equal(want, got) {
 		t.Errorf("bedrock-basic golden drift — diff:\nWANT:\n%s\n\nGOT:\n%s",
 			string(want), string(got))

--- a/internal/profile/golden_test.go
+++ b/internal/profile/golden_test.go
@@ -1,0 +1,37 @@
+package profile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEncodeMobileConfig_GoldenBedrockBasic pins the byte-exact output of
+// EncodeMobileConfig for the bedrock-basic template with fixed UUIDs.
+// This catches any accidental drift in XML formatting or key ordering.
+//
+// Regenerate via: GEN_GOLDEN=1 go test -run TestGoldenGen ./internal/profile/...
+func TestEncodeMobileConfig_GoldenBedrockBasic(t *testing.T) {
+	path := filepath.Join("testdata", "bedrock-basic.golden.mobileconfig")
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden: %v (run GEN_GOLDEN=1 go test -run TestGoldenGen ... to create it)", err)
+	}
+	p, err := LoadTemplate("bedrock-basic")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	got, err := EncodeMobileConfig(p, MobileConfigOpts{
+		ConfigurationPayloadUUID: "00000000-0000-4000-8000-000000000000",
+		PayloadUUID:              "11111111-1111-4111-8111-111111111111",
+		PayloadIdentifier:        "com.example.cowork-mdm.bedrock-basic",
+	})
+	if err != nil {
+		t.Fatalf("EncodeMobileConfig: %v", err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Errorf("bedrock-basic golden drift — diff:\nWANT:\n%s\n\nGOT:\n%s",
+			string(want), string(got))
+	}
+}

--- a/internal/profile/helpers_test.go
+++ b/internal/profile/helpers_test.go
@@ -1,0 +1,7 @@
+package profile
+
+import "os"
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/profile/json_impl.go
+++ b/internal/profile/json_impl.go
@@ -1,0 +1,10 @@
+package profile
+
+import "encoding/json"
+
+// jsonUnmarshalImpl delegates to the standard library. Split out so tests
+// can override the `jsonUnmarshal` variable without touching the whole
+// decoder body.
+func jsonUnmarshalImpl(s string, v any) error {
+	return json.Unmarshal([]byte(s), v)
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,193 @@
+// Package profile represents a Claude Desktop MDM configuration as a typed,
+// format-agnostic Go value. Encoders transform it into .mobileconfig / plist /
+// .reg / Jamf / Intune formats; decoders parse those back. All encoders and
+// decoders share the same Profile type so round-tripping is safe.
+//
+// Values are validated against the embedded schema on Set() — unknown keys
+// and type mismatches surface immediately rather than at encode time.
+package profile
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+// Profile is an in-memory MDM configuration. Insertion order is preserved so
+// encoded output is deterministic.
+type Profile struct {
+	// Name is used as the PayloadDisplayName in mobileconfig output and as a
+	// filename hint when callers export to disk.
+	Name string
+
+	entries     []Entry
+	index       map[string]int // key → entries index
+	unknownKeys []UnknownKey   // keys decoded from input that aren't in the schema
+}
+
+// Entry preserves insertion order.
+type Entry struct {
+	Key   string
+	Value any
+}
+
+// UnknownKey is a key decoded from an input file that isn't in the current
+// schema. Decoders attach these to the returned Profile rather than dropping
+// them, so `profile validate` and `profile status` can surface drift.
+type UnknownKey struct {
+	Key      string
+	RawValue string // stringified representation for reporting only
+}
+
+// DecodeReport accompanies the Profile returned by decoders.
+type DecodeReport struct {
+	UnknownKeys []UnknownKey
+	Warnings    []string
+}
+
+// UnknownKeyError is returned by Validate when a profile contains a key the
+// schema doesn't recognize. Callers can errors.As into this type to
+// distinguish from type-mismatch errors.
+type UnknownKeyError struct {
+	Key string
+}
+
+func (e *UnknownKeyError) Error() string { return fmt.Sprintf("profile: unknown key %q", e.Key) }
+
+// New returns an empty Profile with the given display name.
+func New(name string) *Profile {
+	return &Profile{
+		Name:  name,
+		index: make(map[string]int),
+	}
+}
+
+// Set stores value under key. Validates against the schema. Replaces any
+// existing entry (preserving its insertion position).
+//
+// Returns *UnknownKeyError if key is unknown, or a descriptive error if the
+// value doesn't match the key's declared type.
+func (p *Profile) Set(key string, value any) error {
+	k := schema.Load().Find(key)
+	if k == nil {
+		return &UnknownKeyError{Key: key}
+	}
+	if err := k.Validate(value); err != nil {
+		return fmt.Errorf("profile: %s: %w", key, err)
+	}
+	if idx, ok := p.index[key]; ok {
+		p.entries[idx].Value = value
+		return nil
+	}
+	p.entries = append(p.entries, Entry{Key: key, Value: value})
+	p.index[key] = len(p.entries) - 1
+	return nil
+}
+
+// SetRaw stores a value without schema validation. For internal use by
+// decoders that have already classified a value. Prefer Set for user input.
+func (p *Profile) SetRaw(key string, value any) {
+	if idx, ok := p.index[key]; ok {
+		p.entries[idx].Value = value
+		return
+	}
+	p.entries = append(p.entries, Entry{Key: key, Value: value})
+	p.index[key] = len(p.entries) - 1
+}
+
+// Get returns the value stored under key and whether it exists.
+func (p *Profile) Get(key string) (any, bool) {
+	idx, ok := p.index[key]
+	if !ok {
+		return nil, false
+	}
+	return p.entries[idx].Value, true
+}
+
+// Keys returns keys in insertion order.
+func (p *Profile) Keys() []string {
+	out := make([]string, len(p.entries))
+	for i, e := range p.entries {
+		out[i] = e.Key
+	}
+	return out
+}
+
+// Entries returns entries in insertion order. The returned slice is a copy
+// so callers can't mutate profile state through it.
+func (p *Profile) Entries() []Entry {
+	out := make([]Entry, len(p.entries))
+	copy(out, p.entries)
+	return out
+}
+
+// Delete removes a key. No-op if absent. Preserves order for remaining
+// entries. Also clears any matching UnknownKey side-channel record so
+// Validate doesn't double-report a removed entry.
+func (p *Profile) Delete(key string) {
+	if idx, ok := p.index[key]; ok {
+		p.entries = append(p.entries[:idx], p.entries[idx+1:]...)
+		delete(p.index, key)
+		for i := idx; i < len(p.entries); i++ {
+			p.index[p.entries[i].Key] = i
+		}
+	}
+	// Prune matching unknown-key records.
+	filtered := p.unknownKeys[:0]
+	for _, uk := range p.unknownKeys {
+		if uk.Key != key {
+			filtered = append(filtered, uk)
+		}
+	}
+	p.unknownKeys = filtered
+}
+
+// Len returns the number of entries.
+func (p *Profile) Len() int {
+	return len(p.entries)
+}
+
+// Validate re-validates every entry against the current schema. Aggregates
+// errors via errors.Join so callers can see all problems at once. Unknown
+// keys are reported once even if they appear both as a regular entry (from
+// decoder's SetRaw round-trip preservation) and in the side-channel
+// unknownKeys slice.
+func (p *Profile) Validate() error {
+	s := schema.Load()
+	var errs []error
+	reported := make(map[string]bool)
+	for _, e := range p.entries {
+		k := s.Find(e.Key)
+		if k == nil {
+			if !reported[e.Key] {
+				errs = append(errs, &UnknownKeyError{Key: e.Key})
+				reported[e.Key] = true
+			}
+			continue
+		}
+		if err := k.Validate(e.Value); err != nil {
+			errs = append(errs, fmt.Errorf("profile: %s: %w", e.Key, err))
+		}
+	}
+	for _, uk := range p.unknownKeys {
+		if !reported[uk.Key] {
+			errs = append(errs, &UnknownKeyError{Key: uk.Key})
+			reported[uk.Key] = true
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// AttachUnknownKey records a key that was present in decoded input but isn't
+// in the current schema. Used by decoders only.
+func (p *Profile) AttachUnknownKey(key, raw string) {
+	p.unknownKeys = append(p.unknownKeys, UnknownKey{Key: key, RawValue: raw})
+}
+
+// UnknownKeys returns keys decoded from input but not present in the schema.
+func (p *Profile) UnknownKeys() []UnknownKey {
+	out := make([]UnknownKey, len(p.unknownKeys))
+	copy(out, p.unknownKeys)
+	return out
+}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,137 @@
+package profile
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSetRejectsUnknownKey(t *testing.T) {
+	p := New("x")
+	err := p.Set("notAKey", "val")
+	if err == nil {
+		t.Fatal("Set on unknown key should error")
+	}
+	var uk *UnknownKeyError
+	if !errors.As(err, &uk) {
+		t.Errorf("error should be *UnknownKeyError, got %T", err)
+	}
+	if uk.Key != "notAKey" {
+		t.Errorf("Key = %q, want %q", uk.Key, "notAKey")
+	}
+}
+
+func TestSetValidatesType(t *testing.T) {
+	p := New("x")
+	// inferenceProvider is an enum — must be string, and within allowed set
+	if err := p.Set("inferenceProvider", 42); err == nil {
+		t.Error("Set(inferenceProvider, int) should error (schema says enum/string)")
+	}
+	if err := p.Set("inferenceProvider", "bedrock"); err != nil {
+		t.Errorf("Set(inferenceProvider, bedrock) should succeed, got %v", err)
+	}
+	if err := p.Set("inferenceProvider", "not-a-real-provider"); err == nil {
+		t.Error("Set(inferenceProvider, invalid enum) should error")
+	}
+}
+
+func TestGetReturnsStoredValue(t *testing.T) {
+	p := New("x")
+	if err := p.Set("inferenceProvider", "bedrock"); err != nil {
+		t.Fatal(err)
+	}
+	v, ok := p.Get("inferenceProvider")
+	if !ok || v != "bedrock" {
+		t.Errorf("Get = (%v, %v), want (bedrock, true)", v, ok)
+	}
+}
+
+func TestKeysPreserveInsertionOrder(t *testing.T) {
+	p := New("x")
+	seq := []struct {
+		k string
+		v any
+	}{
+		{"inferenceProvider", "bedrock"},
+		{"inferenceBedrockRegion", "us-west-2"},
+		{"disableDeploymentModeChooser", true},
+	}
+	for _, s := range seq {
+		if err := p.Set(s.k, s.v); err != nil {
+			t.Fatalf("Set %s: %v", s.k, err)
+		}
+	}
+	got := p.Keys()
+	want := []string{"inferenceProvider", "inferenceBedrockRegion", "disableDeploymentModeChooser"}
+	if len(got) != len(want) {
+		t.Fatalf("Keys() length = %d, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("Keys()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSetReplacesPreservesPosition(t *testing.T) {
+	p := New("x")
+	_ = p.Set("inferenceProvider", "bedrock")
+	_ = p.Set("inferenceBedrockRegion", "us-west-2")
+	// Overwrite the first entry — it should stay at index 0.
+	_ = p.Set("inferenceProvider", "vertex")
+	keys := p.Keys()
+	if keys[0] != "inferenceProvider" {
+		t.Errorf("after overwrite, keys[0] = %q, want inferenceProvider", keys[0])
+	}
+	v, _ := p.Get("inferenceProvider")
+	if v != "vertex" {
+		t.Errorf("overwrite did not replace value: got %v", v)
+	}
+}
+
+func TestDeleteShiftsIndex(t *testing.T) {
+	p := New("x")
+	_ = p.Set("inferenceProvider", "bedrock")
+	_ = p.Set("inferenceBedrockRegion", "us-west-2")
+	_ = p.Set("disableDeploymentModeChooser", true)
+	p.Delete("inferenceBedrockRegion")
+	if _, ok := p.Get("inferenceBedrockRegion"); ok {
+		t.Error("deleted key still present")
+	}
+	// remaining order and indexing intact
+	keys := p.Keys()
+	if len(keys) != 2 || keys[0] != "inferenceProvider" || keys[1] != "disableDeploymentModeChooser" {
+		t.Errorf("Keys after delete = %v", keys)
+	}
+	if _, ok := p.Get("disableDeploymentModeChooser"); !ok {
+		t.Error("non-deleted key no longer retrievable (index corruption)")
+	}
+}
+
+func TestValidateAggregatesErrors(t *testing.T) {
+	p := New("x")
+	_ = p.Set("inferenceProvider", "bedrock")
+	// Use SetRaw to slip in a bad value past Set's front-door validation.
+	p.SetRaw("inferenceBedrockRegion", 42) // should be string
+	p.AttachUnknownKey("fooBar", "xyz")
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("Validate should error for bad type + unknown key")
+	}
+	// errors.Join yields a multi-error; check both concerns surface.
+	got := err.Error()
+	if !containsSubstring(got, "fooBar") {
+		t.Errorf("Validate error missing unknown key: %s", got)
+	}
+	if !containsSubstring(got, "inferenceBedrockRegion") {
+		t.Errorf("Validate error missing type-mismatch key: %s", got)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/profile/templates.go
+++ b/internal/profile/templates.go
@@ -1,0 +1,161 @@
+package profile
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+//go:embed templates/*.yaml
+var templateFS embed.FS
+
+// templateDoc is the on-disk YAML format. Values are stored as any so we can
+// preserve JSON-shaped jsonString/stringArray values verbatim.
+type templateDoc struct {
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description"`
+	Values      map[string]any `yaml:"values"`
+	ProfileName string         `yaml:"profile_name,omitempty"` // optional display name override
+}
+
+// LoadTemplate reads the named built-in template. Names match the file
+// basename (without .yaml). An unknown name returns an error listing the
+// available templates.
+func LoadTemplate(name string) (*Profile, error) {
+	data, err := readTemplate(name)
+	if err != nil {
+		return nil, err
+	}
+	return instantiate(data)
+}
+
+// LoadTemplateFile is the same but from a caller-supplied filesystem path.
+// Used by `profile new --from path/to/my-profile.yaml` to keep enterprise-
+// specific configs (with ARNs, tokens, etc.) outside the binary.
+func LoadTemplateFile(rawYAML []byte) (*Profile, error) {
+	var doc templateDoc
+	if err := yaml.Unmarshal(rawYAML, &doc); err != nil {
+		return nil, fmt.Errorf("template: %w", err)
+	}
+	if doc.Name == "" {
+		return nil, fmt.Errorf("template: missing required `name` field")
+	}
+	return instantiate(&doc)
+}
+
+// TemplateNames returns all built-in template names, sorted.
+func TemplateNames() []string {
+	entries, err := templateFS.ReadDir("templates")
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if !strings.HasSuffix(n, ".yaml") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(n, ".yaml"))
+	}
+	sort.Strings(names)
+	return names
+}
+
+func readTemplate(name string) (*templateDoc, error) {
+	fname := path.Join("templates", name+".yaml")
+	b, err := fs.ReadFile(templateFS, fname)
+	if err != nil {
+		avail := strings.Join(TemplateNames(), ", ")
+		return nil, fmt.Errorf("template %q not found (available: %s)", name, avail)
+	}
+	var doc templateDoc
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return nil, fmt.Errorf("template %q: %w", name, err)
+	}
+	return &doc, nil
+}
+
+// instantiate turns a parsed templateDoc into a Profile, validating each
+// value against the schema. Unknown keys error out immediately — templates
+// must stay in sync with the schema.
+func instantiate(doc *templateDoc) (*Profile, error) {
+	profileName := doc.ProfileName
+	if profileName == "" {
+		profileName = doc.Name
+	}
+	p := New(profileName)
+	s := schema.Load()
+
+	// Preserve a stable order (YAML map iteration is unordered in yaml.v3).
+	keys := make([]string, 0, len(doc.Values))
+	for k := range doc.Values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := normalizeTemplateValue(doc.Values[k])
+		// Templates are human-written YAML. For ergonomics we let authors
+		// write JSON-shaped arrays (stringArray) or JSON objects
+		// (jsonString) as a quoted string, and parse them here so schema
+		// validation accepts them.
+		if sk := s.Find(k); sk != nil {
+			switch sk.Type {
+			case schema.TypeStringArray:
+				if str, ok := v.(string); ok {
+					var arr []string
+					if err := json.Unmarshal([]byte(str), &arr); err != nil {
+						return nil, fmt.Errorf("template %q: %s: expected JSON array of strings, got %q: %w",
+							doc.Name, k, str, err)
+					}
+					v = arr
+				}
+			case schema.TypeJSONString:
+				// jsonString stays as a JSON-text string; if the YAML value
+				// is already structured (map/slice), re-marshal to string.
+				if _, ok := v.(string); !ok {
+					b, err := json.Marshal(v)
+					if err != nil {
+						return nil, fmt.Errorf("template %q: %s: cannot marshal to JSON: %w",
+							doc.Name, k, err)
+					}
+					v = string(b)
+				}
+			}
+		}
+		if err := p.Set(k, v); err != nil {
+			return nil, fmt.Errorf("template %q: %w", doc.Name, err)
+		}
+	}
+	return p, nil
+}
+
+// normalizeTemplateValue converts YAML-parsed numeric types (int in yaml.v3)
+// so that schema integer validation accepts them. YAML bools and strings
+// pass through. Nested maps/slices become []any / map[string]any and the
+// caller (profile.Set → schema.Validate) handles them.
+func normalizeTemplateValue(v any) any {
+	switch t := v.(type) {
+	case int:
+		return int64(t)
+	case uint:
+		return int64(t)
+	case float64:
+		// YAML integers load as int, not float64, so any float64 here is
+		// truly meant to be a float. But our schema has no float type, so
+		// preserve it as-is and let validate complain.
+		return t
+	default:
+		return v
+	}
+}

--- a/internal/profile/templates/bedrock-basic.yaml
+++ b/internal/profile/templates/bedrock-basic.yaml
@@ -1,0 +1,30 @@
+name: bedrock-basic
+description: |
+  AWS Bedrock inference provider, using the ~/.aws profile on each user's machine.
+  Replace the ARN placeholders with your own inference-profile ARNs before deployment.
+
+  This template is a scaffold: it does NOT lock down MCP or egress. Layer
+  those via --set or a --from <your-overrides>.yaml.
+
+values:
+  inferenceProvider: bedrock
+
+  # Skip the first-launch "choose login mode" screen. Safe when provider
+  # keys below are fully populated.
+  disableDeploymentModeChooser: true
+
+  # AWS region that hosts your Bedrock inference-profile ARNs.
+  inferenceBedrockRegion: us-west-2
+
+  # AWS profile name (from ~/.aws/credentials) to use. The app copies the
+  # user's ~/.aws into its sandbox at session start, so each user needs a
+  # local profile of this name.
+  inferenceBedrockProfile: default
+
+  # JSON array of ARNs. First entry is the picker default. Use the [1m]
+  # suffix inside a name to offer the 1M-token-context variant for that
+  # model (only if your account has that entitlement).
+  #
+  # Replace ACCOUNT / REGION / PROFILE_ID with your own values.
+  inferenceModels: >-
+    ["arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/OPUS_PROFILE_ID","arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/SONNET_PROFILE_ID[1m]","arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/HAIKU_PROFILE_ID"]

--- a/internal/profile/templates/foundry.yaml
+++ b/internal/profile/templates/foundry.yaml
@@ -1,0 +1,16 @@
+name: foundry
+description: |
+  Azure AI Foundry backend. Replace resource name + API key with your
+  foundry deployment's details.
+
+values:
+  inferenceProvider: foundry
+
+  disableDeploymentModeChooser: true
+
+  inferenceFoundryResource: my-foundry-resource
+  inferenceFoundryApiKey: REPLACE_WITH_YOUR_FOUNDRY_API_KEY
+
+  # Required for Foundry. List the models your deployment exposes.
+  inferenceModels: >-
+    ["claude-opus-4","claude-sonnet-4"]

--- a/internal/profile/templates/gateway.yaml
+++ b/internal/profile/templates/gateway.yaml
@@ -1,0 +1,28 @@
+name: gateway
+description: |
+  Claude Desktop talking to a self-hosted or third-party LLM gateway
+  (inferenceProvider=gateway). Replace base URL and auth scheme with your
+  gateway's actual config.
+
+values:
+  inferenceProvider: gateway
+
+  disableDeploymentModeChooser: true
+
+  # Full URL of the gateway endpoint — usually something like
+  # https://llm-gateway.example.corp
+  inferenceGatewayBaseUrl: https://llm-gateway.example.corp
+
+  # How to authenticate. Options:
+  #   bearer     — Authorization: Bearer <token>  (default)
+  #   x-api-key  — x-api-key: <token>             (for api.anthropic.com-compatible)
+  #   sso        — OAuth device-code flow; no static key
+  inferenceGatewayAuthScheme: bearer
+
+  # Gateway API key. Remove this line if using SSO / inferenceCredentialHelper.
+  inferenceGatewayApiKey: REPLACE_WITH_YOUR_API_KEY_OR_REMOVE
+
+  # Optional: pin a model list. Without this the gateway's /v1/models result
+  # is used. Uncomment and fill to restrict.
+  # inferenceModels: >-
+  #   ["claude-opus-4","claude-sonnet-4","claude-haiku-4-5"]

--- a/internal/profile/templates/mcp-only.yaml
+++ b/internal/profile/templates/mcp-only.yaml
@@ -1,0 +1,25 @@
+name: mcp-only
+description: |
+  Skeleton for managed MCP servers and egress, without setting a provider.
+  Use this when you want to overlay MCP + egress rules onto an existing
+  provider profile (via `cowork-mdm profile merge` in a future release),
+  or standalone if the host's provider config lives elsewhere.
+
+  IMPORTANT: Do NOT commit actual MCP server URLs with embedded tokens to
+  source control. Populate these in your enterprise deployment script, not
+  in this template. The placeholder here is intentionally obvious.
+
+values:
+  # Allow all egress so MCP servers can reach anything. Tighten this in
+  # production by listing specific hostnames instead of ["*"].
+  coworkEgressAllowedHosts: >-
+    ["*"]
+
+  # Managed MCP servers — one array entry per server. Each entry needs at
+  # least {name, url, transport}. Add toolPolicy to auto-allow specific
+  # tools (otherwise every call prompts the user). See schema for details.
+  #
+  # REMOVE THIS PLACEHOLDER and fill in your actual MCP endpoints before
+  # deploying. Leave the jsonString well-formed JSON.
+  managedMcpServers: >-
+    [{"name":"REPLACE_ME","url":"https://mcp.example.corp/sse","transport":"sse","toolPolicy":{}}]

--- a/internal/profile/templates/vertex.yaml
+++ b/internal/profile/templates/vertex.yaml
@@ -1,0 +1,24 @@
+name: vertex
+description: |
+  Google Cloud Vertex AI backend. Requires a GCP project with Vertex +
+  Anthropic models enabled. Replace project/region with your values.
+
+values:
+  inferenceProvider: vertex
+
+  disableDeploymentModeChooser: true
+
+  inferenceVertexProjectId: my-gcp-project
+  inferenceVertexRegion: us-east5
+
+  # Option A: use a service-account JSON file. Absolute path, no tilde.
+  inferenceVertexCredentialsFile: /etc/claude/vertex-sa.json
+
+  # Option B (uncomment instead): Sign in with Google via OAuth Desktop app.
+  # inferenceVertexOAuthClientId: "00000000-0000-0000-0000-000000000000.apps.googleusercontent.com"
+  # inferenceVertexOAuthClientSecret: "GOCSPX-..."
+
+  # Required for Vertex. Replace with the model IDs available in your
+  # project (claude-opus-4, claude-sonnet-4, claude-haiku-4-5, etc.).
+  inferenceModels: >-
+    ["claude-opus-4","claude-sonnet-4","claude-haiku-4-5"]

--- a/internal/profile/templates_test.go
+++ b/internal/profile/templates_test.go
@@ -1,0 +1,128 @@
+package profile
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTemplateNames_IncludesAllFive(t *testing.T) {
+	names := TemplateNames()
+	want := []string{"bedrock-basic", "foundry", "gateway", "mcp-only", "vertex"}
+	if len(names) != len(want) {
+		t.Fatalf("TemplateNames() = %v, want %v", names, want)
+	}
+	for i, n := range want {
+		if names[i] != n {
+			t.Errorf("TemplateNames()[%d] = %q, want %q", i, names[i], n)
+		}
+	}
+}
+
+func TestLoadTemplate_UnknownErrors(t *testing.T) {
+	_, err := LoadTemplate("does-not-exist")
+	if err == nil {
+		t.Fatal("LoadTemplate on unknown name should error")
+	}
+	// error should list available templates to help the user
+	if !strings.Contains(err.Error(), "bedrock-basic") {
+		t.Errorf("error should list available templates, got: %s", err)
+	}
+}
+
+func TestLoadTemplate_BedrockBasic(t *testing.T) {
+	p, err := LoadTemplate("bedrock-basic")
+	if err != nil {
+		t.Fatalf("LoadTemplate bedrock-basic: %v", err)
+	}
+	if p.Name != "bedrock-basic" {
+		t.Errorf("Name = %q", p.Name)
+	}
+	if v, _ := p.Get("inferenceProvider"); v != "bedrock" {
+		t.Errorf("inferenceProvider = %v", v)
+	}
+	if v, _ := p.Get("inferenceBedrockRegion"); v != "us-west-2" {
+		t.Errorf("inferenceBedrockRegion = %v", v)
+	}
+	// Placeholder ARN is an obvious marker — don't let templates leak real ARNs.
+	v, _ := p.Get("inferenceModels")
+	arr, ok := v.([]string)
+	if !ok {
+		t.Fatalf("inferenceModels should be []string after template load, got %T: %v", v, v)
+	}
+	joined := strings.Join(arr, " ")
+	if !strings.Contains(joined, "ACCOUNT") {
+		t.Errorf("inferenceModels should contain ACCOUNT placeholder, got %v", arr)
+	}
+}
+
+func TestLoadTemplate_AllTemplatesValidate(t *testing.T) {
+	for _, name := range TemplateNames() {
+		t.Run(name, func(t *testing.T) {
+			p, err := LoadTemplate(name)
+			if err != nil {
+				t.Fatalf("LoadTemplate %s: %v", name, err)
+			}
+			// All keys set via LoadTemplate pass through Profile.Set which
+			// validates against the schema, so reaching here is implicit
+			// schema compliance. Additional: Validate() should succeed
+			// even for placeholder values, because placeholders are strings
+			// of the correct shape.
+			if err := p.Validate(); err != nil {
+				t.Errorf("template %s has validation errors: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestLoadTemplate_MCPOnlyDoesNotLeakRealData(t *testing.T) {
+	// Regression guard: mcp-only template is a documented skeleton; it
+	// must NOT contain any real MCP URL with embedded token-looking
+	// query parameters (Authorization=..., token=..., etc.).
+	p, err := LoadTemplate("mcp-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := p.Get("managedMcpServers")
+	s := v.(string)
+	for _, tok := range []string{"Authorization=", "access_token=", "@bigmodel", "@anthropic"} {
+		if strings.Contains(s, tok) {
+			t.Errorf("mcp-only template leaks data containing %q — check templates/mcp-only.yaml", tok)
+		}
+	}
+	if !strings.Contains(s, "REPLACE_ME") {
+		t.Errorf("mcp-only template should contain REPLACE_ME placeholder, got %s", s)
+	}
+}
+
+func TestLoadTemplateFile_FromRawYAML(t *testing.T) {
+	raw := []byte(`
+name: custom
+description: test
+values:
+  inferenceProvider: vertex
+  inferenceVertexProjectId: my-project
+  inferenceVertexRegion: us-east5
+  inferenceModels: '["claude-opus-4"]'
+`)
+	p, err := LoadTemplateFile(raw)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile: %v", err)
+	}
+	if v, _ := p.Get("inferenceProvider"); v != "vertex" {
+		t.Errorf("inferenceProvider = %v", v)
+	}
+	if v, _ := p.Get("inferenceVertexProjectId"); v != "my-project" {
+		t.Errorf("projectId = %v", v)
+	}
+}
+
+func TestLoadTemplateFile_MissingName(t *testing.T) {
+	raw := []byte(`description: bad
+values:
+  inferenceProvider: bedrock
+`)
+	_, err := LoadTemplateFile(raw)
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Errorf("expected name-missing error, got %v", err)
+	}
+}

--- a/internal/profile/testdata/bedrock-basic.golden.mobileconfig
+++ b/internal/profile/testdata/bedrock-basic.golden.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.anthropic.claudefordesktop</string>
+			<key>PayloadIdentifier</key>
+			<string>com.example.cowork-mdm.bedrock-basic.settings</string>
+			<key>PayloadUUID</key>
+			<string>11111111-1111-4111-8111-111111111111</string>
+			<key>PayloadDisplayName</key>
+			<string>bedrock-basic</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>disableDeploymentModeChooser</key>
+			<true/>
+			<key>inferenceBedrockProfile</key>
+			<string>default</string>
+			<key>inferenceBedrockRegion</key>
+			<string>us-west-2</string>
+			<key>inferenceModels</key>
+			<string>[&quot;arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/OPUS_PROFILE_ID&quot;,&quot;arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/SONNET_PROFILE_ID[1m]&quot;,&quot;arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/HAIKU_PROFILE_ID&quot;]</string>
+			<key>inferenceProvider</key>
+			<string>bedrock</string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>bedrock-basic</string>
+	<key>PayloadIdentifier</key>
+	<string>com.example.cowork-mdm.bedrock-basic</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>00000000-0000-4000-8000-000000000000</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadScope</key>
+	<string>System</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Foundation for all profile subcommands. Ships:

- **Profile data model** (profile.go) — ordered entries, unknown-key tracking, Validate
- **Encoders**: EncodeMobileConfig (Apple Configuration Profile) + EncodePlist (bare managed-prefs body)
- **Decoders**: DecodeMobileConfig / DecodePlist — order-preserving, unknown-key reporting
- **Templates**: 5 built-in YAML skeletons (bedrock-basic, gateway, vertex, foundry, mcp-only) with only placeholders, no real data
- **LoadTemplateFile(rawYAML)** for enterprise-specific configs that stay out of source control
- **Golden file** pinning bedrock-basic output byte-exact with fixed UUIDs

Adds dep: \`gopkg.in/yaml.v3\`.

## Sparring trail

codex:rescue raised 3 MUST-FIX + 1 SHOULD-FIX + 2 NIT — all fixed in-tree:
- MobileConfigOpts fields renamed to match spec (PayloadUUID = inner, ConfigurationPayloadUUID = outer)
- Decoders use orderedDict, not Go maps, so round-tripping preserves insertion order
- Encoder no longer smuggles errors into XML comments — returns them as errors
- Delete() prunes UnknownKey side channel; Validate() dedupes
- randomUUID fallback returns literal zero UUID on crypto/rand failure
- Parser docstring corrected

## Test plan

- [x] \`go test ./internal/profile/... -race\` 18 tests pass
- [x] plutil -lint check included for darwin runs
- [x] Golden file byte-exact comparison (regenerate via \`GEN_GOLDEN=1\`)
- [x] Cross-build darwin/windows/linux × amd64+arm64 clean
- [x] verify.sh task-03 PASS
- [x] Sparring APPROVE (after fixes)
- [x] Regression guard: mcp-only template scanned for auth-token shapes

## Downstream

Unblocks task-04 (jamf encoder — trivial reuse), task-05 (intune), task-06 (reg), task-apply (managed/ uses Profile + EncodePlist + decoders), task-10 (TUI wizard builds Profiles), task-11 (CLI wiring).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)