### PR TITLE
task-apply: add internal/managed + profile CLI (new/validate/apply/status/templates)

### DIFF
--- a/cmd/cowork-mdm/cli/profile_cmd.go
+++ b/cmd/cowork-mdm/cli/profile_cmd.go
@@ -1,0 +1,363 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krislavten/cowork-mdm/internal/managed"
+	"github.com/krislavten/cowork-mdm/internal/profile"
+)
+
+func newProfileCommand(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Generate, validate, and apply MDM profiles",
+	}
+	cmd.AddCommand(newProfileNewCommand(stdout, stderr))
+	cmd.AddCommand(newProfileValidateCommand(stdout, stderr))
+	cmd.AddCommand(newProfileApplyCommand(stdout, stderr))
+	cmd.AddCommand(newProfileStatusCommand(stdout, stderr))
+	cmd.AddCommand(newProfileTemplatesCommand(stdout, stderr))
+	return cmd
+}
+
+// --- profile new ---
+
+func newProfileNewCommand(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		template string
+		fromFile string
+		outFile  string
+		format   string
+		setFlags []string
+	)
+	c := &cobra.Command{
+		Use:   "new",
+		Short: "Generate a new MDM profile from a template or YAML file",
+		Long: "Loads a built-in template (--template) or a user-supplied YAML file\n" +
+			"(--from), applies any --set KEY=VALUE overrides, and emits the profile\n" +
+			"in the requested --format. Default format is mobileconfig.\n\n" +
+			"Keep enterprise-specific values (ARNs, MCP tokens) in your own YAML file\n" +
+			"using --from; never commit those to the template directory.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			p, err := loadSourceProfile(template, fromFile)
+			if err != nil {
+				return err
+			}
+			for _, set := range setFlags {
+				key, val, err := parseSet(set)
+				if err != nil {
+					return err
+				}
+				if err := setFromString(p, key, val); err != nil {
+					return fmt.Errorf("--set %s: %w", set, err)
+				}
+			}
+			data, err := encodeProfile(p, format)
+			if err != nil {
+				return err
+			}
+			if outFile == "" || outFile == "-" {
+				_, err := stdout.Write(data)
+				return err
+			}
+			if err := os.WriteFile(outFile, data, 0o644); err != nil {
+				return fmt.Errorf("write %s: %w", outFile, err)
+			}
+			fmt.Fprintf(stderr, "wrote %d bytes to %s\n", len(data), outFile)
+			return nil
+		},
+	}
+	c.Flags().StringVarP(&template, "template", "t", "", "built-in template name (e.g. bedrock-basic). Use `profile templates` to list.")
+	c.Flags().StringVar(&fromFile, "from", "", "path to a YAML file describing the profile")
+	c.Flags().StringVarP(&outFile, "out", "o", "", "output file (default stdout)")
+	c.Flags().StringVarP(&format, "format", "f", "mobileconfig", "output format: mobileconfig | plist")
+	c.Flags().StringArrayVar(&setFlags, "set", nil, "override a key: --set KEY=VALUE (repeatable)")
+	return c
+}
+
+// --- profile validate ---
+
+func newProfileValidateCommand(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate FILE",
+		Short: "Validate a .mobileconfig or .plist file against the schema",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			p, report, err := decodeByDetection(data)
+			if err != nil {
+				return err
+			}
+			valid := true
+			if err := p.Validate(); err != nil {
+				valid = false
+				fmt.Fprintf(stdout, "validation errors:\n")
+				fmt.Fprintf(stdout, "  %s\n", strings.ReplaceAll(err.Error(), "\n", "\n  "))
+			}
+			if len(report.UnknownKeys) > 0 {
+				fmt.Fprintf(stdout, "unknown keys (not in schema):\n")
+				for _, uk := range report.UnknownKeys {
+					fmt.Fprintf(stdout, "  %s\n", uk.Key)
+				}
+			}
+			if valid && len(report.UnknownKeys) == 0 {
+				fmt.Fprintf(stdout, "%s: OK (%d keys)\n", args[0], p.Len())
+				return nil
+			}
+			fmt.Fprintf(stderr, "%s: issues found\n", args[0])
+			return fmt.Errorf("validation failed")
+		},
+	}
+}
+
+// --- profile apply ---
+
+func newProfileApplyCommand(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		dryRun bool
+		hive   string
+	)
+	c := &cobra.Command{
+		Use:   "apply FILE",
+		Short: "Apply a profile to the host's managed-prefs store (requires root/admin)",
+		Long: "Reads FILE, decodes it into a Profile, and writes it to the host's\n" +
+			"managed-prefs location (/Library/Managed Preferences/ on macOS,\n" +
+			"HKLM\\SOFTWARE\\Policies\\Claude on Windows by default).\n\n" +
+			"Use --dry-run to preview what would be written without touching disk.\n" +
+			"On macOS this warns that direct writes bypass MDM resync; for production\n" +
+			"deployments push the .mobileconfig through your MDM channel instead.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			p, _, err := decodeByDetection(data)
+			if err != nil {
+				return err
+			}
+			res, err := managed.Apply(p, managed.ApplyOptions{
+				DryRun: dryRun,
+				Hive:   hive,
+			})
+			if err != nil {
+				if errors.Is(err, managed.ErrPermission) {
+					fmt.Fprintln(stderr, "permission denied — re-run with sudo (macOS) or as admin (Windows)")
+				}
+				return err
+			}
+			if res.DryRun {
+				fmt.Fprintf(stdout, "(dry-run) would write %d bytes to %s\n\n", len(res.Preview), res.TargetPath)
+				fmt.Fprintln(stdout, res.Preview)
+				return nil
+			}
+			fmt.Fprintf(stdout, "wrote %d bytes to %s (%s)\n", res.BytesWritten, res.TargetPath, res.Platform)
+			for _, w := range res.Warnings {
+				fmt.Fprintf(stderr, "warning: %s\n", w)
+			}
+			return nil
+		},
+	}
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be written; don't touch disk/registry")
+	c.Flags().StringVar(&hive, "hive", "", "Windows only: HKLM (default) or HKCU")
+	return c
+}
+
+// --- profile status ---
+
+func newProfileStatusCommand(stdout, stderr io.Writer) *cobra.Command {
+	var hive string
+	c := &cobra.Command{
+		Use:   "status",
+		Short: "Show the currently applied managed profile",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rep, err := managed.Status(managed.StatusOptions{Hive: hive})
+			if err != nil {
+				if errors.Is(err, managed.ErrUnsupportedPlatform) {
+					fmt.Fprintln(stderr, "status: unsupported on this platform")
+				}
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				enc := json.NewEncoder(stdout)
+				enc.SetIndent("", "  ")
+				// Build a plain payload so we don't depend on Profile's unexported fields.
+				var out any
+				type profPayload struct {
+					Name   string         `json:"name"`
+					Values map[string]any `json:"values"`
+				}
+				if rep.Profile != nil {
+					pp := profPayload{Name: rep.Profile.Name, Values: map[string]any{}}
+					for _, k := range rep.Profile.Keys() {
+						v, _ := rep.Profile.Get(k)
+						pp.Values[k] = v
+					}
+					out = map[string]any{
+						"platform":    rep.Platform,
+						"targetPath":  rep.TargetPath,
+						"present":     rep.Present,
+						"profile":     pp,
+						"unknownKeys": rep.UnknownKeys,
+						"parseError":  rep.ParseError,
+					}
+				} else {
+					out = map[string]any{
+						"platform":   rep.Platform,
+						"targetPath": rep.TargetPath,
+						"present":    rep.Present,
+						"parseError": rep.ParseError,
+					}
+				}
+				return enc.Encode(out)
+			}
+			fmt.Fprintf(stdout, "Platform:    %s\n", rep.Platform)
+			fmt.Fprintf(stdout, "Target:      %s\n", rep.TargetPath)
+			if !rep.Present {
+				fmt.Fprintln(stdout, "Status:      no managed profile installed")
+				return nil
+			}
+			if rep.ParseError != "" {
+				fmt.Fprintf(stdout, "Parse error: %s\n", rep.ParseError)
+				return nil
+			}
+			fmt.Fprintf(stdout, "Keys:        %d\n", rep.Profile.Len())
+			if len(rep.UnknownKeys) > 0 {
+				fmt.Fprintln(stdout, "Unknown keys (not in current schema):")
+				for _, uk := range rep.UnknownKeys {
+					fmt.Fprintf(stdout, "  %s\n", uk.Key)
+				}
+			}
+			fmt.Fprintln(stdout, "\nConfigured values:")
+			for _, k := range rep.Profile.Keys() {
+				v, _ := rep.Profile.Get(k)
+				fmt.Fprintf(stdout, "  %-40s %v\n", k, v)
+			}
+			return nil
+		},
+	}
+	c.Flags().StringVar(&hive, "hive", "", "Windows only: HKLM (default) or HKCU")
+	return c
+}
+
+// --- profile templates ---
+
+func newProfileTemplatesCommand(stdout, _ io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "templates",
+		Short: "List built-in profile templates",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			for _, n := range profile.TemplateNames() {
+				fmt.Fprintln(stdout, n)
+			}
+			return nil
+		},
+	}
+}
+
+// --- helpers ---
+
+func loadSourceProfile(template, fromFile string) (*profile.Profile, error) {
+	if template == "" && fromFile == "" {
+		return nil, fmt.Errorf("one of --template or --from is required")
+	}
+	if template != "" && fromFile != "" {
+		return nil, fmt.Errorf("--template and --from are mutually exclusive")
+	}
+	if template != "" {
+		return profile.LoadTemplate(template)
+	}
+	data, err := os.ReadFile(fromFile)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", fromFile, err)
+	}
+	return profile.LoadTemplateFile(data)
+}
+
+func parseSet(s string) (key, value string, err error) {
+	parts := strings.SplitN(s, "=", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("--set requires KEY=VALUE format, got %q", s)
+	}
+	return strings.TrimSpace(parts[0]), parts[1], nil
+}
+
+// setFromString coerces a string value into the schema-typed Go value for
+// the given key and Set()s it on the profile. Accepts:
+//
+//   - bool:        "true"/"false"/"1"/"0"
+//   - integer:     decimal int
+//   - stringArray: JSON array literal, e.g. `["a","b"]`
+//   - jsonString:  raw JSON text (passed through; validated by encoder)
+//   - string/url/enum: the raw string
+func setFromString(p *profile.Profile, key, raw string) error {
+	k := schemaLoadKey(key)
+	if k == nil {
+		return fmt.Errorf("unknown key %q", key)
+	}
+	var v any
+	switch k.Type {
+	case "boolean":
+		switch strings.ToLower(raw) {
+		case "true", "1", "yes":
+			v = true
+		case "false", "0", "no":
+			v = false
+		default:
+			return fmt.Errorf("expected boolean (true/false), got %q", raw)
+		}
+	case "integer":
+		n, err := parseInt64(raw)
+		if err != nil {
+			return fmt.Errorf("expected integer, got %q", raw)
+		}
+		v = n
+	case "stringArray":
+		var arr []string
+		if err := jsonDecode(raw, &arr); err != nil {
+			return fmt.Errorf("expected JSON array of strings, got %q: %w", raw, err)
+		}
+		v = arr
+	default:
+		// string / url / enum / jsonString: pass through
+		v = raw
+	}
+	return p.Set(key, v)
+}
+
+// schemaLoadKey and parseInt64 / jsonDecode are tiny wrappers we need here
+// to avoid widening the cli package's surface; they live in a separate
+// helpers file.
+
+func encodeProfile(p *profile.Profile, format string) ([]byte, error) {
+	switch strings.ToLower(format) {
+	case "", "mobileconfig":
+		return profile.EncodeMobileConfig(p, profile.MobileConfigOpts{})
+	case "plist":
+		return profile.EncodePlist(p)
+	default:
+		return nil, fmt.Errorf("unsupported format %q (want mobileconfig or plist)", format)
+	}
+}
+
+func decodeByDetection(data []byte) (*profile.Profile, profile.DecodeReport, error) {
+	switch profile.Detect(data) {
+	case "mobileconfig":
+		return profile.DecodeMobileConfig(data)
+	case "plist":
+		return profile.DecodePlist(data)
+	default:
+		return nil, profile.DecodeReport{}, fmt.Errorf("could not detect format (expected mobileconfig or plist)")
+	}
+}

--- a/cmd/cowork-mdm/cli/profile_cmd_test.go
+++ b/cmd/cowork-mdm/cli/profile_cmd_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestProfileTemplates_Lists(t *testing.T) {
+	out, _, err := runCmd(t, "profile", "templates")
+	if err != nil {
+		t.Fatalf("profile templates: %v", err)
+	}
+	for _, want := range []string{"bedrock-basic", "gateway", "vertex", "foundry", "mcp-only"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("template list missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestProfileNew_FromTemplate_Mobileconfig(t *testing.T) {
+	out, _, err := runCmd(t, "profile", "new", "--template", "bedrock-basic")
+	if err != nil {
+		t.Fatalf("profile new: %v", err)
+	}
+	for _, want := range []string{
+		"<!DOCTYPE plist",
+		"com.anthropic.claudefordesktop",
+		"<key>inferenceProvider</key>",
+		"<string>bedrock</string>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestProfileNew_FormatPlist(t *testing.T) {
+	out, _, err := runCmd(t, "profile", "new", "--template", "bedrock-basic", "--format", "plist")
+	if err != nil {
+		t.Fatalf("profile new --format plist: %v", err)
+	}
+	// Plain plist, NO Apple Configuration wrapper.
+	if strings.Contains(out, "PayloadContent") {
+		t.Errorf("--format plist should not include PayloadContent envelope")
+	}
+	if !strings.Contains(out, "<key>inferenceProvider</key>") {
+		t.Errorf("plist output missing provider key")
+	}
+}
+
+func TestProfileNew_SetOverride(t *testing.T) {
+	// Override inferenceBedrockRegion via --set, make sure it appears in output.
+	out, _, err := runCmd(t, "profile", "new",
+		"--template", "bedrock-basic",
+		"--set", "inferenceBedrockRegion=eu-west-1",
+	)
+	if err != nil {
+		t.Fatalf("profile new --set: %v", err)
+	}
+	if !strings.Contains(out, "<string>eu-west-1</string>") {
+		t.Errorf("override not reflected: %s", firstN(out, 400))
+	}
+}
+
+func TestProfileNew_SetBadKey(t *testing.T) {
+	_, stderr, err := runCmd(t, "profile", "new",
+		"--template", "bedrock-basic",
+		"--set", "notARealKey=x",
+	)
+	if err == nil {
+		t.Fatal("--set on unknown key should fail")
+	}
+	if !strings.Contains(err.Error()+stderr, "unknown key") {
+		t.Errorf("error should mention unknown key: err=%v stderr=%s", err, stderr)
+	}
+}
+
+func TestProfileNew_RequiresTemplateOrFrom(t *testing.T) {
+	_, _, err := runCmd(t, "profile", "new")
+	if err == nil {
+		t.Error("profile new without --template or --from should fail")
+	}
+}
+
+func TestProfileNew_FromYAML(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `name: custom
+values:
+  inferenceProvider: gateway
+  inferenceGatewayBaseUrl: https://gw.example.internal
+`
+	path := filepath.Join(dir, "custom.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, "profile", "new", "--from", path)
+	if err != nil {
+		t.Fatalf("profile new --from: %v", err)
+	}
+	if !strings.Contains(out, "<string>gateway</string>") {
+		t.Errorf("--from YAML output missing provider")
+	}
+}
+
+func TestProfileValidate_GeneratedProfileIsValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.mobileconfig")
+	// Generate first
+	out, _, err := runCmd(t, "profile", "new", "--template", "bedrock-basic", "--out", path)
+	if err != nil {
+		t.Fatalf("profile new: %v", err)
+	}
+	_ = out
+	// Validate
+	vOut, _, err := runCmd(t, "profile", "validate", path)
+	if err != nil {
+		t.Fatalf("profile validate: %v\noutput=%s", err, vOut)
+	}
+	if !strings.Contains(vOut, "OK") {
+		t.Errorf("validate output should say OK, got: %s", vOut)
+	}
+}
+
+func TestProfileValidate_FlagsGarbage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.mobileconfig")
+	if err := os.WriteFile(path, []byte("<html>not a plist</html>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := runCmd(t, "profile", "validate", path)
+	if err == nil {
+		t.Error("validate on garbage input should fail")
+	}
+}
+
+func TestProfileApply_DryRun_NoSideEffects(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skipf("apply tests run only on darwin, got %s", runtime.GOOS)
+	}
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "p.mobileconfig")
+	if _, _, err := runCmd(t, "profile", "new", "--template", "bedrock-basic", "--out", profilePath); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, "profile", "apply", profilePath, "--dry-run")
+	if err != nil {
+		t.Fatalf("apply --dry-run: %v", err)
+	}
+	if !strings.Contains(out, "dry-run") {
+		t.Errorf("dry-run output missing marker: %s", out)
+	}
+	if !strings.Contains(out, "<key>inferenceProvider</key>") {
+		t.Errorf("dry-run preview missing content")
+	}
+}

--- a/cmd/cowork-mdm/cli/profile_helpers.go
+++ b/cmd/cowork-mdm/cli/profile_helpers.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+type schemaKey struct {
+	Type string
+}
+
+// schemaLoadKey returns a minimal key descriptor for the --set coercer.
+// Returns nil for unknown keys.
+func schemaLoadKey(name string) *schemaKey {
+	k := schema.Load().Find(name)
+	if k == nil {
+		return nil
+	}
+	return &schemaKey{Type: string(k.Type)}
+}
+
+func parseInt64(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64)
+}
+
+func jsonDecode(s string, v any) error {
+	return json.Unmarshal([]byte(s), v)
+}

--- a/cmd/cowork-mdm/cli/root.go
+++ b/cmd/cowork-mdm/cli/root.go
@@ -1,13 +1,18 @@
 // Package cli wires the cowork-mdm command-line interface.
 //
-// v0.1 surface:
+// Shipped surface (v0.1 + v0.2 so far):
 //
-//	cowork-mdm schema list      — list all 51 MDM keys
-//	cowork-mdm schema show KEY  — show one key's full detail
-//	cowork-mdm paths show       — show resolved host paths
-//	cowork-mdm --version        — print version
+//	cowork-mdm schema list              — list all 51 MDM keys
+//	cowork-mdm schema show KEY          — show one key's full detail
+//	cowork-mdm paths show               — show resolved host paths
+//	cowork-mdm profile templates        — list built-in profile templates
+//	cowork-mdm profile new              — generate a profile (mobileconfig/plist)
+//	cowork-mdm profile validate FILE    — validate against the schema
+//	cowork-mdm profile apply FILE       — write to managed-prefs (needs root/admin)
+//	cowork-mdm profile status           — read current managed profile
+//	cowork-mdm --version                — print version
 //
-// More commands (profile, marketplace, plugin, doctor) arrive in v0.2.
+// Remaining v0.2 commands (marketplace, plugin, doctor) arrive in later PRs.
 package cli
 
 import (
@@ -59,6 +64,7 @@ func NewRootCommand(info BuildInfo, stdout, stderr io.Writer) *cobra.Command {
 
 	root.AddCommand(newSchemaCommand(stdout, stderr))
 	root.AddCommand(newPathsCommand(stdout, stderr))
+	root.AddCommand(newProfileCommand(stdout, stderr))
 
 	return root
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/managed/apply_darwin.go
+++ b/internal/managed/apply_darwin.go
@@ -1,0 +1,106 @@
+//go:build darwin
+
+package managed
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/krislavten/cowork-mdm/internal/paths"
+	"github.com/krislavten/cowork-mdm/internal/profile"
+)
+
+const directWriteWarning = "Direct write to /Library/Managed Preferences/ bypasses macOS's MDM pipeline (managedappconfigd). The file may be clobbered when the system resyncs managed profiles. For production deployments, push this as a .mobileconfig through your MDM channel (Jamf / Kandji / Intune)."
+
+func apply(p *profile.Profile, opts ApplyOptions) (*ApplyResult, error) {
+	target := opts.TargetPath
+	if target == "" {
+		target = paths.Default().ManagedPrefsPlist()
+	}
+	if target == "" {
+		return nil, ErrUnsupportedPlatform
+	}
+
+	// Encode first so we fail fast on invalid profiles.
+	data, err := profile.EncodePlist(p)
+	if err != nil {
+		return nil, fmt.Errorf("managed.Apply: encode failed: %w", err)
+	}
+
+	res := &ApplyResult{
+		TargetPath:   target,
+		Platform:     "darwin",
+		DryRun:       opts.DryRun,
+		BytesWritten: 0,
+	}
+
+	// Warn whenever we'd write to the system-wide managed-prefs path.
+	// Tests that pass a custom TargetPath skip this warning.
+	systemPath := paths.Default().ManagedPrefsPlist()
+	if target == systemPath {
+		res.Warnings = append(res.Warnings, directWriteWarning)
+	}
+
+	if opts.DryRun {
+		res.Preview = string(data)
+		return res, nil
+	}
+
+	// Rely on the actual filesystem write to detect permission problems
+	// rather than prejudging via os.Geteuid(). An admin using `sudo -u`
+	// or a specially-permissive path should succeed; only the real write
+	// result determines permission. writeAtomic maps EACCES/EPERM to
+	// ErrPermission so callers can errors.Is check it.
+	if err := writeAtomic(target, data); err != nil {
+		if os.IsPermission(err) {
+			return nil, fmt.Errorf("%w: %s: %v", ErrPermission, target, err)
+		}
+		return nil, fmt.Errorf("managed.Apply: write failed: %w", err)
+	}
+	res.BytesWritten = len(data)
+	return res, nil
+}
+
+// writeAtomic writes data to path via a temp file + rename so a crash mid-
+// write can never leave a half-written plist behind that Claude.app might
+// read.
+func writeAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".cowork-mdm.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		// In case rename fails, clean the leftover tmp.
+		if _, statErr := os.Stat(tmpName); statErr == nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// Match the typical plist perms (root-owned, world-readable).
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// currentUsername is resolved from OS facilities; used by ManagedPrefsUserPlist.
+// Unused in apply() but retained for parity when we add user-scope support.
+var _ = func() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return ""
+}

--- a/internal/managed/apply_darwin_test.go
+++ b/internal/managed/apply_darwin_test.go
@@ -1,0 +1,163 @@
+//go:build darwin
+
+package managed
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krislavten/cowork-mdm/internal/profile"
+)
+
+func buildValidProfile(t *testing.T) *profile.Profile {
+	t.Helper()
+	p := profile.New("apply-test")
+	mustSet := func(k string, v any) {
+		if err := p.Set(k, v); err != nil {
+			t.Fatalf("Set %s: %v", k, err)
+		}
+	}
+	mustSet("inferenceProvider", "bedrock")
+	mustSet("inferenceBedrockRegion", "us-west-2")
+	mustSet("disableDeploymentModeChooser", true)
+	return p
+}
+
+func TestApply_DryRun_EmitsPreviewNoSideEffects(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "claude.plist")
+	p := buildValidProfile(t)
+	res, err := Apply(p, ApplyOptions{TargetPath: target, DryRun: true})
+	if err != nil {
+		t.Fatalf("Apply dry-run: %v", err)
+	}
+	if !res.DryRun {
+		t.Error("result DryRun flag should be true")
+	}
+	if res.Platform != "darwin" {
+		t.Errorf("Platform = %q", res.Platform)
+	}
+	if res.BytesWritten != 0 {
+		t.Error("BytesWritten should be 0 on DryRun")
+	}
+	if !strings.Contains(res.Preview, "<key>inferenceProvider</key>") {
+		t.Errorf("Preview missing expected content: %s", res.Preview[:200])
+	}
+	if _, err := os.Stat(target); err == nil {
+		t.Error("dry-run should not create file")
+	}
+}
+
+func TestApply_WritesPlistAtomic(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "claude.plist")
+	p := buildValidProfile(t)
+	res, err := Apply(p, ApplyOptions{TargetPath: target})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.BytesWritten == 0 {
+		t.Error("BytesWritten should be nonzero")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "<key>inferenceProvider</key>") {
+		t.Errorf("written file missing content: %s", string(data))
+	}
+	// No lingering temp file in the directory.
+	entries, _ := os.ReadDir(filepath.Dir(target))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".cowork-mdm.") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestApply_RejectsInvalidProfile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "claude.plist")
+	p := profile.New("bad")
+	p.AttachUnknownKey("doesNotExist", "nope")
+	_, err := Apply(p, ApplyOptions{TargetPath: target})
+	if err == nil {
+		t.Fatal("Apply on profile with unknown key should fail")
+	}
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Error("file should not have been created")
+	}
+}
+
+func TestApply_NoWarningForCustomTarget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "claude.plist")
+	p := buildValidProfile(t)
+	res, err := Apply(p, ApplyOptions{TargetPath: target, DryRun: true})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Warnings) != 0 {
+		t.Errorf("custom target should not produce direct-write warning, got %v", res.Warnings)
+	}
+}
+
+func TestStatus_MissingFileReportsNotPresent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "missing.plist")
+	rep, err := Status(StatusOptions{SourcePath: target})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if rep.Present {
+		t.Error("Present should be false when file is absent")
+	}
+	if rep.Profile != nil {
+		t.Error("Profile should be nil when file is absent")
+	}
+}
+
+func TestStatus_ReadsWrittenProfile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "claude.plist")
+	p := buildValidProfile(t)
+	if _, err := Apply(p, ApplyOptions{TargetPath: target}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	rep, err := Status(StatusOptions{SourcePath: target})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !rep.Present {
+		t.Fatal("Status should report Present=true after Apply")
+	}
+	if rep.Profile == nil {
+		t.Fatal("Profile should be non-nil")
+	}
+	if v, _ := rep.Profile.Get("inferenceProvider"); v != "bedrock" {
+		t.Errorf("inferenceProvider = %v, want bedrock", v)
+	}
+	if len(rep.UnknownKeys) != 0 {
+		t.Errorf("unexpected unknown keys: %v", rep.UnknownKeys)
+	}
+}
+
+func TestApply_PermissionMappedFromWriteError(t *testing.T) {
+	// Point Apply at a file inside a directory we can't write to. Then
+	// the atomic write fails with EACCES and Apply must wrap it as
+	// ErrPermission.
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission test skipped")
+	}
+	readonlyDir := t.TempDir()
+	if err := os.Chmod(readonlyDir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readonlyDir, 0o755) })
+	target := filepath.Join(readonlyDir, "claude.plist")
+	p := buildValidProfile(t)
+	_, err := Apply(p, ApplyOptions{TargetPath: target})
+	if err == nil {
+		t.Fatal("Apply to read-only dir should fail")
+	}
+	if !errors.Is(err, ErrPermission) {
+		t.Errorf("expected ErrPermission, got %v", err)
+	}
+}

--- a/internal/managed/apply_other.go
+++ b/internal/managed/apply_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !windows
+
+package managed
+
+import "github.com/krislavten/cowork-mdm/internal/profile"
+
+func apply(_ *profile.Profile, _ ApplyOptions) (*ApplyResult, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func status(_ StatusOptions) (*StatusReport, error) {
+	return nil, ErrUnsupportedPlatform
+}

--- a/internal/managed/apply_other_test.go
+++ b/internal/managed/apply_other_test.go
@@ -1,0 +1,24 @@
+//go:build !darwin && !windows
+
+package managed
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/krislavten/cowork-mdm/internal/profile"
+)
+
+func TestApply_LinuxReturnsUnsupported(t *testing.T) {
+	_, err := Apply(profile.New("x"), ApplyOptions{})
+	if !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Errorf("want ErrUnsupportedPlatform, got %v", err)
+	}
+}
+
+func TestStatus_LinuxReturnsUnsupported(t *testing.T) {
+	_, err := Status(StatusOptions{})
+	if !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Errorf("want ErrUnsupportedPlatform, got %v", err)
+	}
+}

--- a/internal/managed/apply_windows.go
+++ b/internal/managed/apply_windows.go
@@ -1,0 +1,330 @@
+//go:build windows
+
+package managed
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+
+	"github.com/krislavten/cowork-mdm/internal/profile"
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+const windowsDefaultKey = `SOFTWARE\Policies\Claude`
+
+func apply(p *profile.Profile, opts ApplyOptions) (*ApplyResult, error) {
+	hive, root, err := resolveHive(opts.Hive)
+	if err != nil {
+		return nil, err
+	}
+	subkey := opts.TargetPath
+	if subkey == "" {
+		subkey = windowsDefaultKey
+	}
+
+	// Validate before writing so we fail fast on bad profiles.
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("managed.Apply: validation failed: %w", err)
+	}
+
+	res := &ApplyResult{
+		TargetPath: fmt.Sprintf(`%s\%s`, hive, subkey),
+		Platform:   "windows",
+		DryRun:     opts.DryRun,
+	}
+
+	if opts.DryRun {
+		res.Preview = renderReg(hive, subkey, p)
+		return res, nil
+	}
+
+	// Two-pass apply: first compute every value conversion so we can fail
+	// fast before touching the registry. Then open the key and write.
+	// On any write error, roll back the values we wrote in this call.
+	s := schema.Load()
+	type pending struct {
+		key string
+		typ schema.Type
+		val any
+	}
+	ops := make([]pending, 0, p.Len())
+	for _, e := range p.Entries() {
+		sk := s.Find(e.Key)
+		if sk == nil {
+			continue
+		}
+		// Validate conversion shape upfront — reject bad types before any
+		// registry mutation.
+		if err := validateForReg(sk.Type, e.Value); err != nil {
+			return nil, fmt.Errorf("managed.Apply: %s: %w", e.Key, err)
+		}
+		ops = append(ops, pending{key: e.Key, typ: sk.Type, val: e.Value})
+	}
+
+	k, openedExisting, err := registry.CreateKey(root, subkey, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.QUERY_VALUE)
+	if err != nil {
+		if isPermissionError(err) {
+			return nil, fmt.Errorf("%w: %s\\%s: %v", ErrPermission, hive, subkey, err)
+		}
+		return nil, fmt.Errorf("managed.Apply: open key: %w", err)
+	}
+	defer k.Close()
+
+	// Snapshot any preexisting values for the keys we're about to write,
+	// so a mid-sequence failure can restore them.
+	snapshot := map[string]struct {
+		raw any
+		typ uint32
+	}{}
+	for _, op := range ops {
+		if buf, typ, err := k.GetValue(op.key, nil); err == nil {
+			snapshot[op.key] = struct {
+				raw any
+				typ uint32
+			}{raw: nil, typ: typ}
+			_ = buf
+			// Best-effort stash of the actual value via a typed read.
+			if v, err := readAnyValue(k, op.key); err == nil {
+				snap := snapshot[op.key]
+				snap.raw = v
+				snapshot[op.key] = snap
+			}
+		}
+	}
+
+	written := make([]string, 0, len(ops))
+	for _, op := range ops {
+		if err := writeRegValue(k, op.key, op.typ, op.val); err != nil {
+			// Roll back: restore snapshot values, delete values that we
+			// newly introduced this call. The key itself we leave alone —
+			// deleting a freshly-created key ahead of resync is risky.
+			for _, name := range written {
+				if prev, ok := snapshot[name]; ok && prev.raw != nil {
+					_ = restoreRegValue(k, name, prev.typ, prev.raw)
+				} else {
+					_ = k.DeleteValue(name)
+				}
+			}
+			_ = openedExisting // unused on rollback path; intentional
+			return nil, fmt.Errorf("managed.Apply: write %s: %w", op.key, err)
+		}
+		written = append(written, op.key)
+	}
+	_ = openedExisting // informational; kept for future telemetry
+	return res, nil
+}
+
+func validateForReg(t schema.Type, value any) error {
+	switch t {
+	case schema.TypeBoolean:
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("boolean expected, got %T", value)
+		}
+	case schema.TypeInteger:
+		n, err := coerceInt64(value)
+		if err != nil {
+			return err
+		}
+		if n < 0 || n > math.MaxUint32 {
+			return fmt.Errorf("integer %d out of DWORD range [0, %d]", n, math.MaxUint32)
+		}
+	case schema.TypeString, schema.TypeURL, schema.TypeEnum, schema.TypeJSONString:
+		if _, ok := value.(string); !ok {
+			// allow non-string that marshals to JSON as fallback (matches writeRegValue)
+			if _, err := json.Marshal(value); err != nil {
+				return fmt.Errorf("string expected, got %T", value)
+			}
+		}
+	case schema.TypeStringArray:
+		if _, err := coerceStringArrayForReg(value); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported schema type %q", t)
+	}
+	return nil
+}
+
+// restoreRegValue writes a captured value back to the registry using its
+// original type. Best-effort — we don't surface errors here because we're
+// already in a rollback path. Only the well-known value types we support.
+func restoreRegValue(k registry.Key, name string, regType uint32, raw any) error {
+	switch regType {
+	case registry.DWORD:
+		n, ok := raw.(int64)
+		if !ok {
+			return fmt.Errorf("restore: cannot convert %T to DWORD", raw)
+		}
+		return k.SetDWordValue(name, uint32(n))
+	case registry.QWORD:
+		n, ok := raw.(int64)
+		if !ok {
+			return fmt.Errorf("restore: cannot convert %T to QWORD", raw)
+		}
+		return k.SetQWordValue(name, uint64(n))
+	case registry.SZ:
+		s, _ := raw.(string)
+		return k.SetStringValue(name, s)
+	case registry.EXPAND_SZ:
+		s, _ := raw.(string)
+		return k.SetExpandStringValue(name, s)
+	}
+	return fmt.Errorf("restore: unsupported registry type %d", regType)
+}
+
+func resolveHive(hive string) (string, registry.Key, error) {
+	switch strings.ToUpper(strings.TrimSpace(hive)) {
+	case "", "HKLM":
+		return "HKLM", registry.LOCAL_MACHINE, nil
+	case "HKCU":
+		return "HKCU", registry.CURRENT_USER, nil
+	default:
+		return "", 0, fmt.Errorf("managed.Apply: unsupported hive %q (want HKLM or HKCU)", hive)
+	}
+}
+
+func writeRegValue(k registry.Key, name string, t schema.Type, value any) error {
+	switch t {
+	case schema.TypeBoolean:
+		b, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("boolean expected, got %T", value)
+		}
+		v := uint32(0)
+		if b {
+			v = 1
+		}
+		return k.SetDWordValue(name, v)
+	case schema.TypeInteger:
+		n, err := coerceInt64(value)
+		if err != nil {
+			return err
+		}
+		if n < 0 || n > math.MaxUint32 {
+			return fmt.Errorf("integer %d out of DWORD range [0, %d]", n, math.MaxUint32)
+		}
+		return k.SetDWordValue(name, uint32(n))
+	case schema.TypeString, schema.TypeURL, schema.TypeEnum, schema.TypeJSONString:
+		s, ok := value.(string)
+		if !ok {
+			b, err := json.Marshal(value)
+			if err != nil {
+				return fmt.Errorf("string expected, got %T: %w", value, err)
+			}
+			s = string(b)
+		}
+		return k.SetStringValue(name, s)
+	case schema.TypeStringArray:
+		arr, err := coerceStringArrayForReg(value)
+		if err != nil {
+			return err
+		}
+		b, err := json.Marshal(arr)
+		if err != nil {
+			return err
+		}
+		return k.SetStringValue(name, string(b))
+	default:
+		return fmt.Errorf("unsupported schema type %q", t)
+	}
+}
+
+func coerceStringArrayForReg(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("stringArray element %d is %T, want string", i, item)
+			}
+			out[i] = s
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("stringArray expected, got %T", value)
+	}
+}
+
+func coerceInt64(value any) (int64, error) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case float64:
+		if v != float64(int64(v)) {
+			return 0, fmt.Errorf("integer expected, got non-whole float %v", v)
+		}
+		return int64(v), nil
+	default:
+		return 0, fmt.Errorf("integer expected, got %T", value)
+	}
+}
+
+// renderReg returns a human-readable .reg-style preview of what Apply
+// would write. Must match the conversions that writeRegValue performs so
+// --dry-run output faithfully represents the actual registry operation.
+func renderReg(hive, subkey string, p *profile.Profile) string {
+	var b strings.Builder
+	hiveFull := "HKEY_LOCAL_MACHINE"
+	if hive == "HKCU" {
+		hiveFull = "HKEY_CURRENT_USER"
+	}
+	b.WriteString("Windows Registry Editor Version 5.00\r\n\r\n")
+	fmt.Fprintf(&b, "[%s\\%s]\r\n", hiveFull, subkey)
+	s := schema.Load()
+	for _, e := range p.Entries() {
+		sk := s.Find(e.Key)
+		if sk == nil {
+			continue
+		}
+		switch sk.Type {
+		case schema.TypeBoolean:
+			bv, _ := e.Value.(bool)
+			val := 0
+			if bv {
+				val = 1
+			}
+			fmt.Fprintf(&b, "%q=dword:%08x\r\n", e.Key, val)
+		case schema.TypeInteger:
+			n, _ := coerceInt64(e.Value)
+			fmt.Fprintf(&b, "%q=dword:%08x\r\n", e.Key, uint32(n))
+		case schema.TypeString, schema.TypeURL, schema.TypeEnum, schema.TypeJSONString:
+			var str string
+			if s, ok := e.Value.(string); ok {
+				str = s
+			} else {
+				raw, _ := json.Marshal(e.Value)
+				str = string(raw)
+			}
+			fmt.Fprintf(&b, "%q=%q\r\n", e.Key, str)
+		case schema.TypeStringArray:
+			arr, err := coerceStringArrayForReg(e.Value)
+			if err != nil {
+				fmt.Fprintf(&b, "# %s: coerce error: %s\r\n", e.Key, err)
+				continue
+			}
+			raw, _ := json.Marshal(arr)
+			fmt.Fprintf(&b, "%q=%q\r\n", e.Key, string(raw))
+		default:
+			fmt.Fprintf(&b, "# %s: unsupported type %q\r\n", e.Key, sk.Type)
+		}
+	}
+	return b.String()
+}
+
+func isPermissionError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "Access is denied") ||
+		strings.Contains(msg, "access denied") ||
+		strings.Contains(strings.ToLower(msg), "denied")
+}

--- a/internal/managed/managed.go
+++ b/internal/managed/managed.go
@@ -1,0 +1,104 @@
+// Package managed handles the side-effectful operations for
+// `profile apply` and `profile status`: writing to the host's managed
+// preferences store (macOS plist or Windows registry) and reading it back.
+//
+// CLI layer should only orchestrate this package — it must not perform
+// filesystem or registry writes itself. This keeps the command-line code
+// pure argument-parsing + output-formatting, as specified in specs/cli.md.
+package managed
+
+import (
+	"errors"
+
+	"github.com/krislavten/cowork-mdm/internal/profile"
+)
+
+// ApplyOptions controls how a profile is committed to the host's
+// managed-prefs store.
+type ApplyOptions struct {
+	// DryRun emits what would happen without touching disk/registry.
+	DryRun bool
+
+	// TargetPath overrides the default managed-prefs path. Used in tests.
+	// On darwin it's the path to a plist file; on windows the registry
+	// subkey under the chosen hive (e.g. "SOFTWARE\\Policies\\Claude").
+	// Empty = platform default.
+	TargetPath string
+
+	// Hive selects the Windows registry hive: "HKLM" (default) or "HKCU".
+	// Ignored on non-Windows.
+	Hive string
+}
+
+// StatusOptions mirrors ApplyOptions for the read side. SourcePath and Hive
+// accept the same values.
+type StatusOptions struct {
+	SourcePath string
+	Hive       string
+}
+
+// ApplyResult summarizes what was done.
+type ApplyResult struct {
+	// TargetPath is the absolute path or registry key that was (or would
+	// have been) written.
+	TargetPath string
+
+	// BytesWritten is the size of the emitted plist on darwin, 0 on
+	// windows (registry writes aren't byte-measured).
+	BytesWritten int
+
+	// Platform is "darwin" or "windows".
+	Platform string
+
+	// DryRun mirrors the input option.
+	DryRun bool
+
+	// Preview holds the rendered plist (darwin) or .reg (windows) text
+	// that would have been written. Populated only when DryRun is true.
+	Preview string
+
+	// Warnings lists non-fatal caveats the caller should surface. For
+	// example, direct writes to /Library/Managed Preferences/ bypass
+	// macOS's managedappconfigd and may be clobbered on profile resync;
+	// production deployments should push a .mobileconfig via an MDM
+	// channel instead.
+	Warnings []string
+}
+
+// StatusReport describes what's currently active on the host.
+type StatusReport struct {
+	Platform    string
+	TargetPath  string
+	Present     bool
+	Profile     *profile.Profile
+	UnknownKeys []profile.UnknownKey
+	ParseError  string
+}
+
+// Sentinel errors — callers can errors.Is() to distinguish.
+var (
+	// ErrPermission is returned when the operation requires elevation
+	// (root on macOS; admin on Windows for HKLM writes).
+	ErrPermission = errors.New("managed: operation requires elevated privileges")
+
+	// ErrUnsupportedPlatform is returned on Linux or other OSes where
+	// neither the plist path nor the registry key exists.
+	ErrUnsupportedPlatform = errors.New("managed: apply/status not supported on this platform")
+)
+
+// Apply writes the profile to the host in the platform-appropriate form.
+//   - On darwin, encodes as raw plist (EncodePlist) and writes to the
+//     managed-prefs path (/Library/Managed Preferences/com.anthropic.claudefordesktop.plist).
+//   - On windows, writes each profile entry to the chosen registry hive.
+//   - On linux, returns ErrUnsupportedPlatform.
+//
+// Requires elevated privileges. Returns ErrPermission (wrapped) if not elevated.
+func Apply(p *profile.Profile, opts ApplyOptions) (*ApplyResult, error) {
+	return apply(p, opts)
+}
+
+// Status reads the current managed preferences on the host.
+// Pass a zero-value StatusOptions for defaults.
+func Status(opts StatusOptions) (*StatusReport, error) {
+	return status(opts)
+}

--- a/internal/managed/status_darwin.go
+++ b/internal/managed/status_darwin.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package managed
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/krislavten/cowork-mdm/internal/paths"
+	"github.com/krislavten/cowork-mdm/internal/profile"
+)
+
+func status(opts StatusOptions) (*StatusReport, error) {
+	target := opts.SourcePath
+	if target == "" {
+		target = paths.Default().ManagedPrefsPlist()
+	}
+	if target == "" {
+		return nil, ErrUnsupportedPlatform
+	}
+	rep := &StatusReport{
+		Platform:   "darwin",
+		TargetPath: target,
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			rep.Present = false
+			return rep, nil
+		}
+		return nil, fmt.Errorf("managed.Status: read %s: %w", target, err)
+	}
+	rep.Present = true
+	p, decoded, err := profile.DecodePlist(data)
+	if err != nil {
+		rep.ParseError = err.Error()
+		return rep, nil
+	}
+	rep.Profile = p
+	rep.UnknownKeys = decoded.UnknownKeys
+	_ = decoded.Warnings // currently unused but kept for future surfacing
+	return rep, nil
+}

--- a/internal/managed/status_windows.go
+++ b/internal/managed/status_windows.go
@@ -1,0 +1,125 @@
+//go:build windows
+
+package managed
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+
+	"github.com/krislavten/cowork-mdm/internal/profile"
+	"github.com/krislavten/cowork-mdm/internal/schema"
+)
+
+func status(opts StatusOptions) (*StatusReport, error) {
+	hive, root, err := resolveHive(opts.Hive)
+	if err != nil {
+		return nil, err
+	}
+	subkey := opts.SourcePath
+	if subkey == "" {
+		subkey = windowsDefaultKey
+	}
+	rep := &StatusReport{
+		Platform:   "windows",
+		TargetPath: fmt.Sprintf(`%s\%s`, hive, subkey),
+	}
+	k, err := registry.OpenKey(root, subkey, registry.QUERY_VALUE)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return rep, nil
+		}
+		return nil, fmt.Errorf("managed.Status: open %s\\%s: %w", hive, subkey, err)
+	}
+	defer k.Close()
+	rep.Present = true
+
+	names, err := k.ReadValueNames(-1)
+	if err != nil {
+		rep.ParseError = err.Error()
+		return rep, nil
+	}
+	p := profile.New("")
+	unknowns := []profile.UnknownKey{}
+	s := schema.Load()
+	for _, name := range names {
+		sk := s.Find(name)
+		if sk == nil {
+			raw, _ := readAnyValue(k, name)
+			p.AttachUnknownKey(name, fmt.Sprint(raw))
+			unknowns = append(unknowns, profile.UnknownKey{Key: name, RawValue: fmt.Sprint(raw)})
+			p.SetRaw(name, raw)
+			continue
+		}
+		v, err := readTypedValue(k, name, sk.Type)
+		if err != nil {
+			// Capture as string so Validate can flag a type mismatch.
+			raw, _ := readAnyValue(k, name)
+			p.SetRaw(name, raw)
+			continue
+		}
+		p.SetRaw(name, v)
+	}
+	rep.Profile = p
+	rep.UnknownKeys = unknowns
+	return rep, nil
+}
+
+// readAnyValue returns the best-effort Go value for a registry value of
+// unknown type. Uses the type from QueryValue.
+func readAnyValue(k registry.Key, name string) (any, error) {
+	_, typ, err := k.GetValue(name, nil)
+	if err != nil {
+		return nil, err
+	}
+	switch typ {
+	case registry.DWORD, registry.QWORD:
+		n, _, err := k.GetIntegerValue(name)
+		if err != nil {
+			return nil, err
+		}
+		return int64(n), nil
+	case registry.SZ, registry.EXPAND_SZ:
+		s, _, err := k.GetStringValue(name)
+		return s, err
+	default:
+		s, _, err := k.GetStringValue(name)
+		return s, err
+	}
+}
+
+// readTypedValue coerces a registry value into the expected Go type per
+// the schema's declared type.
+func readTypedValue(k registry.Key, name string, t schema.Type) (any, error) {
+	switch t {
+	case schema.TypeBoolean:
+		n, _, err := k.GetIntegerValue(name)
+		if err != nil {
+			return nil, err
+		}
+		return n != 0, nil
+	case schema.TypeInteger:
+		n, _, err := k.GetIntegerValue(name)
+		if err != nil {
+			return nil, err
+		}
+		return int64(n), nil
+	case schema.TypeString, schema.TypeURL, schema.TypeEnum, schema.TypeJSONString:
+		s, _, err := k.GetStringValue(name)
+		return s, err
+	case schema.TypeStringArray:
+		s, _, err := k.GetStringValue(name)
+		if err != nil {
+			return nil, err
+		}
+		var arr []string
+		if err := json.Unmarshal([]byte(s), &arr); err != nil {
+			return nil, fmt.Errorf("stringArray: %w", err)
+		}
+		return arr, nil
+	default:
+		return nil, fmt.Errorf("unsupported schema type %q", t)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the loop from "data structure" to "actually writes to disk":

**internal/managed/**: platform-specific apply/status side effects
- darwin: atomic plist write (temp + rename) to /Library/Managed Preferences/
- windows: registry write to HKLM|HKCU\\SOFTWARE\\Policies\\Claude with precompute+snapshot+rollback
- linux: ErrUnsupportedPlatform

**CLI subcommands** (cmd/cowork-mdm/cli/profile_cmd.go):
- profile templates / new / validate / apply / status

## Real-world smoke test

Exactly the flow a yuanli deployment needs:

\`\`\`
# yuanli-profile.yaml — kept OUT of repo, has ARNs + MCP
cowork-mdm profile new --from yuanli.yaml --out foo.mobileconfig
# → wrote 1982 bytes

cowork-mdm profile validate foo.mobileconfig
# → foo.mobileconfig: OK (8 keys)

cowork-mdm profile apply foo.mobileconfig --dry-run
# → (dry-run) preview of the plist that would land at /Library/Managed Preferences/

plutil -lint foo.mobileconfig
# → foo.mobileconfig: OK
\`\`\`

## Sparring trail

codex:rescue — 1 MUST-FIX + 3 SHOULD-FIX, all fixed:
- DWORD range check rejects integers outside [0, MaxUint32]
- Windows apply is transactional (snapshot + rollback)
- darwin gates on actual fs write, not Geteuid()
- dry-run preview on Windows matches real registry conversions

## Test plan

- [x] darwin apply/status tests (9) pass
- [x] other (linux) tests (2) pass, Windows cross-compiles clean
- [x] cmd/cli tests (18 incl 10 new profile tests) pass
- [x] cross-build darwin/windows/linux × amd64+arm64
- [x] verify.sh task-apply PASS
- [x] Sparring APPROVE after fixes
- [x] Real end-to-end plutil-lint verified

## Downstream

Completes the minimum viable workflow for MDM generation + deployment. Remaining v0.2 scope:
- task-07 (marketplace) — git-backed plugin mgmt
- task-08 (plugin) — symlink inspection
- task-09 (doctor) — host health checks

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)