### PR TITLE
feat(plugin): v0.3 Claude Code plugin surface for cowork-mdm

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "cowork-mdm",
+  "description": "Claude Desktop enterprise MDM toolkit — profile authoring, org plugin marketplace, per-host diagnostics",
+  "owner": {
+    "name": "krislavten"
+  },
+  "plugins": [
+    {
+      "name": "cowork-mdm",
+      "description": "Drive the cowork-mdm CLI from inside Claude Code: generate Claude Desktop MDM profiles (.mobileconfig / plist), install org plugins from git marketplaces, and diagnose broken hosts. Requires the cowork-mdm CLI on PATH (brew install krislavten/tap/cowork-mdm).",
+      "source": "./plugin",
+      "category": "enterprise",
+      "homepage": "https://github.com/krislavten/cowork-mdm"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > CLI toolkit for deploying Claude Desktop in the enterprise: MDM config profiles, plugin marketplace management, and per-host diagnostics.
 
-**Status**: **v0.1 — schema + path reference.** v0.2 adds profile generation, marketplace management, and diagnostics (in progress — see [docs/execution/TASKS.md](docs/execution/TASKS.md)).
+**Status**: **v0.3 — CLI + Claude Code plugin.** The CLI delivers profile generation, plugin marketplace management, and diagnostics. v0.3 adds a Claude Code plugin layer (skills + slash commands) that teaches an agent how to drive the CLI on the user's behalf. Plugin `v0.3.0` wraps CLI `v0.3.0`; both ship together.
 
 **Not affiliated with Anthropic.** This project is an independent effort based on reverse-engineering the public Claude Desktop application.
 
@@ -25,39 +25,82 @@ brew install cowork-mdm
 
 ## Commands
 
-### Shipped in v0.1
-
 ```bash
+# Schema + path reference
 cowork-mdm schema list                     # all 51 keys (name, type, scope, appMin)
 cowork-mdm schema show inferenceProvider   # details: description, example, allowed values
-
 cowork-mdm paths show                      # host paths cowork-mdm reads
 cowork-mdm paths show --os windows         # simulate a different platform
 
-cowork-mdm --version
-```
-
-Both subcommands accept `--json` for machine-readable output.
-
-### Planned for v0.2
-
-```bash
-# Profile generation
-cowork-mdm profile new --template bedrock-mcp --out my.mobileconfig
+# Profile authoring (YAML → .mobileconfig / plist)
+cowork-mdm profile templates
+cowork-mdm profile new --template bedrock-basic --from overrides.yaml --out my.mobileconfig
 cowork-mdm profile validate my.mobileconfig
-cowork-mdm profile export my.mobileconfig --format reg
+cowork-mdm profile status                  # what's currently active on this host
 
 # Marketplace + plugin management (macOS)
 cowork-mdm marketplace add https://github.com/anthropics/claude-plugins-official
 cowork-mdm marketplace update
-cowork-mdm plugin list / prune
+cowork-mdm plugin list
+cowork-mdm plugin prune
 
 # Diagnostics
 cowork-mdm doctor
 cowork-mdm doctor --fix
 ```
 
-Spec and task breakdown: [`specs/`](specs/) + [`docs/execution/TASKS.md`](docs/execution/TASKS.md).
+Every subcommand accepts `--json` for machine-readable output. Spec and
+task breakdown: [`specs/`](specs/) + [`docs/execution/TASKS.md`](docs/execution/TASKS.md).
+
+## Use as a Claude Code plugin
+
+v0.3 adds a Claude Code plugin layer: five skills + four slash commands
+that teach an agent how to drive the `cowork-mdm` CLI safely on a user's
+behalf. The plugin ships **no new logic** — it's a documentation bundle
+that makes the CLI self-driving inside Claude Code.
+
+### Install (in Claude Code)
+
+```
+/plugin marketplace add https://github.com/krislavten/cowork-mdm
+/plugin install cowork-mdm@cowork-mdm
+```
+
+The CLI itself must still be installed via Homebrew (see Quick start) —
+the plugin reports "CLI missing, install via brew" and stops if `cowork-mdm`
+isn't on `PATH`.
+
+### What the agent gets
+
+**Skills** — loaded automatically when the user's request matches:
+
+| Skill | Loaded when the user asks about … |
+| --- | --- |
+| `cowork-mdm` | generic Claude Desktop MDM questions (routes to a specialist) |
+| `mdm-profile-authoring` | writing / editing a profile, looking up schema keys, Bedrock / Vertex / Azure / gateway recipes |
+| `mdm-profile-deploy` | pushing a profile via Jamf / Intune / Kandji, verifying status, why a config isn't taking effect |
+| `mdm-plugins` | installing or updating `org-plugins/` marketplaces, dangling symlinks |
+| `mdm-doctor` | troubleshooting a broken Claude Desktop install |
+
+**Slash commands** — executable playbooks:
+
+| Command | What it does |
+| --- | --- |
+| `/cowork-mdm:new-profile` | interactive profile generator (pick provider → collect values → generate → validate) |
+| `/cowork-mdm:deploy PATH` | validate + dry-run preview, diff against current host, hand off for MDM push |
+| `/cowork-mdm:doctor` | run `cowork-mdm doctor --json`, interpret findings, suggest specific fixes |
+| `/cowork-mdm:refresh-plugins` | `marketplace update` + `plugin prune` dry-run |
+
+### Safety invariants the plugin enforces
+
+- **Never `sudo`.** Writes to `/Library/Managed Preferences/` and
+  `/Library/Application Support/Claude/` always remain the user's explicit
+  action.
+- **Production deploys go through an MDM channel.** Direct plist writes
+  are clobbered by `managedappconfigd` on the next sync; the plugin
+  refuses that path.
+- **Enterprise secrets stay in the user's overrides YAML**, never in the
+  repo's built-in templates.
 
 ## Contributing
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "cowork-mdm",
+  "version": "0.3.0",
+  "description": "Claude Desktop MDM: author .mobileconfig / plist profiles, manage the org plugin marketplace, diagnose hosts. Drives the cowork-mdm CLI via Bash.",
+  "author": {
+    "name": "krislavten",
+    "url": "https://github.com/krislavten"
+  },
+  "homepage": "https://github.com/krislavten/cowork-mdm"
+}

--- a/plugin/commands/deploy.md
+++ b/plugin/commands/deploy.md
@@ -1,0 +1,58 @@
+---
+allowed-tools: Bash(cowork-mdm:*)
+description: Validate and preview an MDM profile before MDM-channel deployment
+argument-hint: PATH_TO_MOBILECONFIG
+---
+
+## Context
+
+- Profile under review: `$1`
+- cowork-mdm version: !`cowork-mdm --version 2>&1`
+- Validation: !`cowork-mdm profile validate "$1" 2>&1`
+- Dry-run preview (first 60 lines): !`cowork-mdm profile apply "$1" --dry-run 2>&1 | head -60`
+- Current managed plist status on this host: !`cowork-mdm profile status --json 2>&1`
+
+## Your task
+
+Given a `.mobileconfig` (or `.plist`) at `$1`, walk the user through a
+pre-deployment review. **This command never writes to disk.** It validates,
+previews, and hands off.
+
+### Steps
+
+1. **Check validation** — if the `cowork-mdm profile validate` output
+   above reports errors, stop and surface them to the user. Do not
+   proceed to deployment guidance until validation is clean.
+
+2. **Summarize the profile** — read the dry-run preview context above and
+   tell the user which keys will be set, which provider is configured,
+   and whether any high-impact flags (`disableDeploymentModeChooser`,
+   broad `coworkEgressAllowedHosts`) are turned on.
+
+3. **Diff against current host state** — the `cowork-mdm profile status
+   --json` context shows what's currently active on this Mac. Compare
+   the two key sets and call out:
+   - keys being **added** by this profile
+   - keys being **changed** (value differs)
+   - keys being **removed** (present today, absent in the new profile)
+
+4. **Hand off for MDM deployment** — the right path is:
+   - For production: upload to Jamf / Intune / Kandji / Mosyle /
+     Addigy as a custom configuration profile with the payload type
+     `com.anthropic.claudefordesktop`. Do NOT try to do this from the
+     CLI — that's the admin console's job.
+   - For a local developer test only: tell the user they can run
+     `sudo cowork-mdm profile apply "$1"` themselves, but warn them
+     that macOS's `managedappconfigd` will clobber the plist on the
+     next MDM sync, so this is not a production path.
+
+### Rules
+
+- **Never** run `sudo cowork-mdm profile apply`. Never write into
+  `/Library/Managed Preferences/` directly. This plugin does not elevate.
+- If the user asks you to deploy in production without going through
+  their MDM, refuse and explain the `managedappconfigd` clobber from
+  the `mdm-profile-deploy` skill.
+- If validation failed, do not show the dry-run preview to the user as
+  "what will happen" — the profile is invalid and the preview is
+  misleading.

--- a/plugin/commands/doctor.md
+++ b/plugin/commands/doctor.md
@@ -1,0 +1,50 @@
+---
+allowed-tools: Bash(cowork-mdm:*)
+description: Diagnose the local Claude Desktop install using cowork-mdm doctor
+---
+
+## Context
+
+- cowork-mdm version: !`cowork-mdm --version 2>&1`
+- Host paths: !`cowork-mdm paths show --json 2>&1`
+- Doctor report: !`cowork-mdm doctor --json 2>&1`
+
+## Your task
+
+Parse the JSON doctor report from context and help the user understand
+each finding. Follow the `mdm-doctor` skill's decision tree for
+interpretation.
+
+### Steps
+
+1. **Parse and group** the JSON findings by status:
+   - `error` — needs attention (blockers)
+   - `warning` — informational / non-blocking
+   - `ok` — mention count, don't list each
+   - `skipped` — only mention if the user is on an unsupported platform
+
+2. **For each error/warning**, in order:
+   - Restate the finding in plain language.
+   - Suggest the most likely cause (from the `mdm-doctor` skill's
+     decision tree).
+   - Propose a specific next command, not `--fix` blindly.
+
+3. **Decide whether to recommend `--fix`** — only if ALL remaining non-OK
+   findings have `fixAvailable: true` AND the fixes are low-risk
+   (creating the `org-plugins/` directory, pruning dangling symlinks).
+   Do not suggest `--fix` for anything that would touch
+   `/Library/Managed Preferences/` (the doctor doesn't attempt those
+   anyway, but surface the distinction to the user).
+
+4. **Offer hand-offs** when a finding is better handled by another skill:
+   - Plist issues → `mdm-profile-deploy`
+   - Plugin/symlink issues → `mdm-plugins`
+   - Profile authoring questions → `mdm-profile-authoring`
+
+### Rules
+
+- Do **not** run `cowork-mdm doctor --fix` without asking the user first.
+- Do **not** `sudo` anything.
+- If the doctor context above shows a CLI error (e.g. CLI not on PATH),
+  stop and ask the user to install `cowork-mdm` — the rest of the
+  diagnosis is meaningless without it.

--- a/plugin/commands/new-profile.md
+++ b/plugin/commands/new-profile.md
@@ -1,0 +1,82 @@
+---
+allowed-tools: Bash(cowork-mdm:*), Read, Write
+description: Interactively author a new Claude Desktop MDM profile
+---
+
+## Context
+
+- cowork-mdm version: !`cowork-mdm --version 2>&1 || echo "MISSING — ask user to install via brew install krislavten/tap/cowork-mdm"`
+- Available templates: !`cowork-mdm profile templates 2>&1`
+
+## Your task
+
+Walk the user through generating a `.mobileconfig` that configures Claude
+Desktop for their enterprise. Follow this flow — do **not** skip steps:
+
+### 1. Establish intent
+
+Ask exactly which inference provider the user wants to configure (one of
+`bedrock`, `vertex`, `foundry`, `gateway`, or `mcp-only`), and whether they
+additionally want to lock down MCP servers and/or egress. If the user is
+unsure, route to the `mdm-profile-authoring` skill and show the provider
+matrix from there.
+
+### 2. Collect the enterprise-specific values
+
+For each provider, ask only for the values that actually vary per org.
+Don't pester for keys the template already defaults correctly. Typical
+asks:
+
+- **bedrock**: AWS region, AWS profile name, Bedrock inference-profile
+  ARN list (one per model). Warn about the `[1m]` suffix for 1M-token
+  variants.
+- **vertex**: GCP project, region, model IDs.
+- **foundry**: Azure endpoint, deployment names.
+- **gateway**: base URL, auth header, model list.
+- Optional for all: `managedMcpServers` (MCP server list as JSON) and
+  `coworkEgressAllowedHosts` (JSON array).
+
+Confirm whether to set `disableDeploymentModeChooser: true`. Remind that
+this flag hard-gates on the inference config being complete — leaving it
+off is safer for a first deploy.
+
+### 3. Write `overrides.yaml`
+
+Create a YAML file in the user's working directory (default
+`./overrides.yaml`). `inferenceModels` and `coworkEgressAllowedHosts` are
+`stringArray` keys — accept either a YAML list or a JSON-array-in-a-string
+form. `managedMcpServers` is a `jsonString` — must be a single-line valid
+JSON string of the shape `schema show managedMcpServers` describes. Never
+put secrets in the built-in templates; the overrides YAML stays private to
+the user.
+
+### 4. Generate and validate
+
+```bash
+cowork-mdm profile new \
+  --template <provider> \
+  --from overrides.yaml \
+  --out profile.mobileconfig
+cowork-mdm profile validate profile.mobileconfig
+```
+
+If validate fails, read the error, fix the YAML, regenerate. Do not ship
+an invalid profile.
+
+### 5. Preview and hand off
+
+Show the user the first ~40 lines of `profile.mobileconfig` so they can
+spot-check. Tell them the next step is **not** local apply — it's handing
+the file to their MDM (Jamf/Intune/Kandji). If they want to test locally
+on this very Mac, suggest `/cowork-mdm:deploy profile.mobileconfig` which
+runs a dry-run preview without touching disk.
+
+### Rules
+
+- Do **not** run `sudo` yourself. Ever.
+- Do **not** write `profile.mobileconfig` anywhere under `/Library/…`.
+- Do **not** modify files under the cowork-mdm repo's `internal/profile/
+  templates/` directory. Enterprise-specific values live in the user's
+  overrides YAML.
+- Refer to the `mdm-profile-authoring` skill for schema/type questions
+  the user raises mid-flow.

--- a/plugin/commands/refresh-plugins.md
+++ b/plugin/commands/refresh-plugins.md
@@ -1,0 +1,55 @@
+---
+allowed-tools: Bash(cowork-mdm:*)
+description: Update all Claude Desktop plugin marketplaces and clean dangling symlinks
+---
+
+## Context
+
+- cowork-mdm version: !`cowork-mdm --version 2>&1`
+- Current marketplaces: !`cowork-mdm marketplace list --json 2>&1`
+- Current plugins: !`cowork-mdm plugin list --json 2>&1`
+- Dangling symlinks (dry-run prune): !`cowork-mdm plugin prune 2>&1`
+
+## Your task
+
+Drive the daily-refresh workflow for Claude Desktop plugin marketplaces.
+See the `mdm-plugins` skill for the underlying model.
+
+### Steps
+
+1. **Report current state** from the context above — how many
+   marketplaces, how many plugins, how many dangling links.
+
+2. **Update all marketplaces** (needs sudo — ask the user to run it;
+   do NOT sudo yourself):
+
+   ```bash
+   sudo cowork-mdm marketplace update
+   ```
+
+   After the user runs it, re-read `cowork-mdm marketplace list --json`
+   and report any change in HEAD SHAs or plugin counts.
+
+3. **Re-check plugins** with `cowork-mdm plugin list --json`. Compare
+   against the pre-update snapshot from context: note added, removed,
+   newly-dangling.
+
+4. **Prune dangling** only if any appeared. Ask the user to run:
+
+   ```bash
+   sudo cowork-mdm plugin prune --yes
+   ```
+
+   Do not run `sudo` yourself. Explain that prune removes symlinks only,
+   never real directories.
+
+5. **Final summary** — total marketplaces, total live plugins, HEAD SHAs.
+
+### Rules
+
+- Never run `sudo`. Hand the command to the user.
+- Never `rm -rf` anything under `/Library/Application Support/Claude/`.
+  The only way to remove a marketplace is `cowork-mdm marketplace remove`.
+- If a marketplace has a non-fast-forward git state (the `update` output
+  reports a conflict), stop and ask the user before doing anything
+  destructive — someone may have hand-edited files in the clone.

--- a/plugin/skills/cowork-mdm/SKILL.md
+++ b/plugin/skills/cowork-mdm/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: cowork-mdm
+description: Router for Claude Desktop enterprise administration — loads when the user mentions cowork-mdm by name or asks a generic question about Managed Preferences for Claude Desktop that doesn't clearly belong to profile authoring, deployment, plugins, or diagnostics. Hands off to a specialist sub-skill. Prefer the specialists directly when the user's intent is specific (writing a profile, deploying one, managing org plugins, or troubleshooting a host).
+---
+
+# cowork-mdm — router
+
+`cowork-mdm` is a Go CLI that generates and inspects Managed Preferences config
+for Claude Desktop. It also manages the org plugin marketplace and diagnoses
+hosts. The plugin version ships **no new logic** — every command is a thin
+wrapper around `cowork-mdm` invocations.
+
+## Pre-flight: the CLI must be on PATH
+
+```bash
+cowork-mdm --version  # → 0.3.0 (commit ..., built ...)
+```
+
+If this fails, stop and tell the user to install it:
+
+```bash
+brew install krislavten/tap/cowork-mdm
+# or download a binary from https://github.com/krislavten/cowork-mdm/releases
+```
+
+Do not try to work around a missing CLI. The plugin cannot do anything useful
+without it.
+
+## Pick a sub-skill by task
+
+| User wants to … | Load sub-skill | Typical commands |
+| --- | --- | --- |
+| Look up a Managed Preferences key, draft / edit a profile for Bedrock/Vertex/Azure/Gateway/MCP-only | **mdm-profile-authoring** | `schema list`, `schema show KEY`, `profile templates`, `profile new --template … --from …`, `profile validate` |
+| Push an existing profile to real hosts; investigate why it isn't taking effect | **mdm-profile-deploy** | `profile apply --dry-run`, `profile status` |
+| Install / update / remove org plugin marketplaces; clean dangling symlinks | **mdm-plugins** | `marketplace add/list/update/remove`, `plugin list/show/prune` |
+| Diagnose a specific user's broken Claude Desktop install | **mdm-doctor** | `paths show`, `doctor`, `doctor --fix`, `doctor --json` |
+
+## Slash commands you can offer
+
+- `/cowork-mdm:new-profile` — interactive profile generator.
+- `/cowork-mdm:deploy PATH` — validate + preview a profile before MDM push.
+- `/cowork-mdm:doctor` — run diagnostics + explain each finding.
+- `/cowork-mdm:refresh-plugins` — update all marketplaces + clean symlinks.
+
+## Two ground rules (both apply to every sub-skill)
+
+1. **Prefer `--json` whenever you need to reason about output.** Parse the
+   JSON, then narrate. The human-formatted tables drift; the JSON contract
+   is stable.
+2. **Never `sudo`, never write to `/Library/Managed Preferences/` directly.**
+   Production deployments go through an MDM channel (Jamf / Intune / Kandji /
+   Mosyle). `profile apply` without `--dry-run` is a direct write and will be
+   clobbered by macOS's `managedappconfigd` on the next MDM sync. If the user
+   insists on a local test, hand them the `sudo` command, don't run it.
+
+Past those two rules, defer to the specialist skill.

--- a/plugin/skills/mdm-doctor/SKILL.md
+++ b/plugin/skills/mdm-doctor/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: mdm-doctor
+description: Diagnosing a broken Claude Desktop install — the managed profile isn't being read, plugins aren't showing up, the app won't launch, or the user's config differs from what the admin pushed. Load when the user is troubleshooting rather than setting up — phrases like "Claude Desktop won't launch", "doctor", "diagnose this host", "why isn't my profile active", "debug Claude", "something's broken with Claude Desktop". Uses `cowork-mdm doctor` to enumerate host state.
+---
+
+# MDM doctor
+
+This skill covers **diagnosis**. The entry point is `cowork-mdm doctor`,
+which enumerates every thing that can be wrong with a Claude Desktop
+install and returns a structured result per check.
+
+## The command in three forms
+
+```bash
+cowork-mdm doctor              # human table; exit non-zero on any error
+cowork-mdm doctor --json       # structured; parse this when reasoning
+cowork-mdm doctor --fix        # attempt auto-fix on any fixAvailable non-OK check
+```
+
+**Always start with `doctor --json`**, parse it, then decide what to do.
+Don't chain to `--fix` blindly — some fixes modify the filesystem and the
+user may not want them.
+
+## JSON result shape
+
+```json
+{
+  "platform": "darwin",
+  "results": [
+    {
+      "id": "app.installed",
+      "name": "Claude Desktop installed",
+      "status": "ok" | "warning" | "error" | "skipped",
+      "message": "/Applications/Claude.app",
+      "detail": "…",
+      "fixAvailable": false
+    }
+  ],
+  "summary": {"ok": 9, "total": 9}
+}
+```
+
+Key fields to parse:
+
+- `results[].id` — dotted identifier (e.g. `app.installed`, `plist.exists`,
+  `plist.schema`, `orgplugins.exists`, `orgplugins.symlinks`,
+  `orgplugins.dangling`, `marketplace.repos-operable`, `user.sessions`,
+  `git.available`).
+- `results[].status` — one of `ok` / `warning` / `error` / `skipped`.
+- `results[].fixAvailable` — boolean; `--fix` only attempts to repair
+  checks where this is true.
+- `summary` — counts by status. Fast path: if `summary.ok == summary.total`
+  the host is clean; otherwise walk `results` for the non-OK entries.
+
+Status semantics:
+
+- `skipped` — check doesn't apply on this OS (e.g. registry checks on
+  macOS). Not a problem.
+- `warning` — non-blocking anomaly. Usually informational.
+- `error` — exit-1 condition. At least one means Claude Desktop almost
+  certainly has a functional issue.
+
+## Decision tree by finding
+
+### `app.installed` error
+
+Claude Desktop isn't installed (or is in an unexpected location). Fix:
+user installs from the download page. No amount of plugin/profile work
+matters until the app is on disk.
+
+### `plist.exists` error on macOS
+
+No managed plist found at either system or user path.
+- If the user **expected** a managed profile → MDM push never landed, or
+  landed under the wrong bundle identifier. Switch to `mdm-profile-deploy`.
+- If the user **didn't** push a profile → this is expected; the app falls
+  back to 1p mode. Not a bug.
+
+### `plist.schema` error
+
+The plist is there but malformed (broken XML, wrong encoding). This is a
+sign of hand-editing gone wrong or a truncated MDM push, OR a schema-
+invalid plist (unknown keys, wrong types). Possible causes:
+- **Unknown keys** — newer app than CLI, or a hand-typed typo like
+  `inferenceBedrockRegionn`. Check the check's `detail` field for the
+  offending key name, then `cowork-mdm schema list --json` for canonical
+  names.
+- **Malformed XML** — `plutil -lint <path>` to see the XML error.
+  Regenerate via MDM push, not by hand.
+
+### `orgplugins.exists` error
+
+`/Library/Application Support/Claude/org-plugins/` is missing. Claude
+Desktop creates it on first launch, so this error usually means the user
+hasn't launched the app yet, or they're on a fresh install. `--fix`
+creates the directory.
+
+### `orgplugins.symlinks` warning
+
+Top-level entries exist that aren't valid (pointing outside the managed
+marketplaces). Likely hand-installed plugins. Not broken, just
+non-standard.
+
+### `orgplugins.dangling` warning
+
+Dangling symlinks present. These log warnings at every Claude launch. Fix:
+`cowork-mdm plugin prune --yes` (it's `fixAvailable: true` — `--fix` does
+this).
+
+### `user.sessions` warning
+
+No user session DB found. Means no one has actually launched Claude
+Desktop on this Mac since install. Not a problem if the user knows that.
+
+### `marketplace.repos-operable` warning
+
+Inconsistency between `org-plugins/<name>/` directories and the top-level
+symlinks. Usually from a half-completed `marketplace remove`. Fix:
+`cowork-mdm marketplace update` rebuilds links.
+
+### `git.available` error
+
+`git` isn't on PATH or isn't callable. `marketplace add/update` uses
+go-git internally so it works without a system git, but the doctor still
+reports this as it makes manual debugging harder.
+
+## The `--fix` contract
+
+`--fix` runs checks whose JSON shows `fixAvailable: true` and attempts
+remediation. What it can fix today:
+
+- Create missing `org-plugins/` directory.
+- Prune dangling top-level symlinks.
+
+What it will **not** fix:
+
+- Anything that requires writing to `/Library/Managed Preferences/` —
+  `mdm-profile-deploy` rule 1 applies.
+- Missing Claude.app install.
+- Plist schema errors (refuses to rewrite potentially hand-tuned content).
+
+Before running `--fix`, tell the user exactly which checks will be
+affected. `--fix --json` prints the results after attempted fixes.
+
+## Reading `cowork-mdm paths show` for context
+
+```bash
+cowork-mdm paths show --json
+```
+
+Returns the exact paths `cowork-mdm` is consulting. The JSON uses
+**PascalCase** field names — `ClaudeAppPath`, `ManagedPrefsPlist`,
+`ManagedPrefsUserPlist(<you>)`, `OrgPluginsDir`, `UserSessionsDir`,
+`LaunchAgentDir`, `WindowsRegistryPath`. Parse with those exact keys.
+
+If the user has customized any of these (e.g. Parallels/VDI installs where
+`/Library/Application Support/Claude/` is bind-mounted elsewhere), the
+doctor checks against the defaults and will report errors even when the
+app is functional. Suspect this when the user swears the config works.
+
+## Suggested diagnostic flow
+
+```
+1. cowork-mdm paths show --json            # confirm where we're looking
+2. cowork-mdm doctor --json                # enumerate findings
+3. For each error/warning, consult the decision tree above
+4. Propose specific commands, don't run --fix blindly
+5. For profile-specific issues, hand off to mdm-profile-deploy
+6. For plugin-specific issues, hand off to mdm-plugins
+```
+
+## What doctor does NOT check
+
+- Whether `inferenceModels` ARNs are valid / the user has Bedrock
+  entitlement — that's an AWS-side question.
+- Whether MCP servers in `managedMcpServers` are reachable — ping them
+  yourself.
+- Whether the user's Claude Desktop version satisfies each key's
+  `appMin` — you can cross-check with `schema show KEY` and
+  `/Applications/Claude.app/Contents/Info.plist`.

--- a/plugin/skills/mdm-plugins/SKILL.md
+++ b/plugin/skills/mdm-plugins/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: mdm-plugins
+description: Managing Claude Desktop's org plugin library — cloning plugin marketplaces from git, updating them, linking individual plugins into the `org-plugins/` directory, and cleaning up dangling symlinks. Load when the user wants to install, update, or remove plugins/marketplaces for the Claude Desktop app (distinct from Claude Code plugins) — phrases like "install plugin", "add marketplace", "org-plugins", "plugin not showing up", "dangling symlink", "marketplace update", or asks about `/Library/Application Support/Claude/org-plugins/`.
+---
+
+# Claude Desktop org plugins
+
+This skill covers plugins **for the Claude Desktop app** (the Electron
+binary), not for Claude Code. The two systems share the "plugin" word but
+live in different directories and have separate lifecycles.
+
+- **Claude Desktop plugins** live under
+  `/Library/Application Support/Claude/org-plugins/` and are visible to
+  every user on that Mac.
+- **Claude Code plugins** (what this very plugin is) install via
+  `/plugin marketplace add` inside Claude Code.
+
+This skill is about the first kind.
+
+## The symlink model (you must understand this)
+
+`org-plugins/` is a flat directory. Claude Desktop reads every top-level
+entry and treats it as a plugin, **regardless of whether it's a real
+directory or a symlink**.
+
+`cowork-mdm` organizes that directory as follows:
+
+```
+/Library/Application Support/Claude/org-plugins/
+├── claude-plugins-official/         ← real dir: `git clone` target
+│   ├── .claude-plugin/marketplace.json
+│   ├── plugins/<plugin-name>/…      ← actual plugin payloads
+│   └── external_plugins/<name>/…
+├── rush-plugin/                     ← second marketplace
+│   └── plugins/<plugin-name>/…
+│
+│   ↓ top-level symlinks that cowork-mdm (re)generates:
+├── agent-sdk-dev → claude-plugins-official/plugins/agent-sdk-dev
+├── rush-ai      → rush-plugin/plugins/rush-ai
+├── …
+```
+
+Every marketplace is one `git clone`. Top-level entries are **symlinks**
+pointing into each marketplace's `plugins/` or `external_plugins/`
+subdirectory. Claude Desktop sees flat names; updates are git pulls.
+
+**If a top-level symlink dangles** (target moved/renamed), Claude Desktop
+will log a warning and skip the plugin. `cowork-mdm plugin prune` removes
+these.
+
+## The four CLI commands you'll use
+
+| Command | What it does |
+| --- | --- |
+| `cowork-mdm marketplace add URL [--name N]` | `git clone URL` into `org-plugins/N` (default: basename of URL) and auto-runs link-all. |
+| `cowork-mdm marketplace update [NAME]` | `git pull` on one or all marketplaces, then rebuilds top-level symlinks. |
+| `cowork-mdm marketplace list [--json]` | Shows marketplaces + HEAD SHA + plugin count. |
+| `cowork-mdm marketplace remove NAME` | Removes the clone and every symlink that pointed into it. Prompts unless `--yes`. |
+
+And at the individual-plugin level:
+
+| Command | What it does |
+| --- | --- |
+| `cowork-mdm plugin list [--json]` | Lists every top-level entry, classified as `ok` / `dangling` / `real-dir`. |
+| `cowork-mdm plugin show NAME` | Full detail: source marketplace, target, manifest, per-user enabled state. |
+| `cowork-mdm plugin unlink NAME` | Removes a top-level symlink. Refuses to touch real directories. |
+| `cowork-mdm plugin prune [--yes]` | Removes dangling symlinks. Dry-run by default. |
+
+All commands that mutate `org-plugins/` require write access to
+`/Library/Application Support/Claude/` — in practice, `sudo`. The plugin
+never `sudo`s for you.
+
+## Canonical workflow: install the official marketplace
+
+```bash
+cowork-mdm marketplace add https://github.com/anthropics/claude-plugins-public
+# → clones to /Library/Application Support/Claude/org-plugins/claude-plugins-public
+# → rebuilds top-level symlinks for every plugin in that repo
+
+cowork-mdm marketplace list
+# NAME                     HEAD        PLUGINS  LAST-PULL
+# claude-plugins-public    abc1234     47       2026-05-01 10:22
+
+cowork-mdm plugin list | head
+```
+
+Run it as your own user on macOS — most installs require **sudo** to write
+into `/Library/Application Support/Claude/`. Hand the user the command
+prefixed with `sudo`; don't run `sudo` yourself.
+
+## Canonical workflow: daily refresh
+
+```bash
+cowork-mdm marketplace update           # pull every marketplace
+cowork-mdm plugin prune                 # dry-run: lists dangling links
+cowork-mdm plugin prune --yes           # commit the prune
+```
+
+The `/cowork-mdm:refresh-plugins` slash command wraps this.
+
+## Canonical workflow: add a plugin from a new marketplace
+
+```bash
+cowork-mdm marketplace add https://github.com/example/claude-plugins
+cowork-mdm plugin list --json | jq '.[] | select(.Source | contains("example"))'
+```
+
+`plugin list --json` uses PascalCase fields: `Name`, `Source` (e.g.
+`marketplace:claude-plugins-official`), `TargetPath`, `IsSymlink`,
+`Dangling`, `Manifest`. Parse with those exact keys.
+
+No per-plugin install step exists — adding a marketplace auto-links every
+plugin inside it. If you want to un-expose one plugin, `plugin unlink NAME`
+removes just that top-level symlink while keeping the marketplace intact.
+
+## Diagnosing "plugin doesn't show up"
+
+```bash
+cowork-mdm plugin list --json | jq '.[] | select(.Name=="THE_PLUGIN")'
+```
+
+Read the resulting entry:
+
+- **`Dangling: true`** → the target path no longer exists. Most common
+  cause: you `marketplace remove`d one marketplace that was providing this
+  plugin. Fix: `plugin prune`.
+- **`IsSymlink: false`** → it's a real directory at the top level, not a
+  managed symlink. Usually from manually copying in a plugin. Either convert
+  it to a marketplace-managed one or leave it alone and stop worrying.
+- **not listed at all** → the marketplace that ships it isn't installed,
+  or the marketplace's `.claude-plugin/marketplace.json` omits it. Check
+  `marketplace list` and the source repo.
+
+## Per-user enabled state
+
+Claude Desktop stores each user's enabled/disabled plugin choices in the
+user's session DB. `cowork-mdm plugin show NAME` reports this across all
+users it can see — useful for confirming whether an install actually
+reached the end user or just sits idle in `org-plugins/`.
+
+## Gotchas
+
+- **Don't delete a marketplace's real directory with `rm -rf`.** Use
+  `cowork-mdm marketplace remove NAME` — it cleans up the symlinks too.
+  Orphan symlinks in `org-plugins/` surface as dangling entries every
+  Claude launch and spam the logs.
+- **`org-plugins/` write requires elevated permissions on macOS.** The CLI
+  fails loud if it can't write. Prefix with `sudo` — the user runs it.
+- **Marketplaces are git repos, not packages.** There's no version pinning;
+  whatever `main` (or the branch you cloned) has at pull time is what
+  ships. If you need a pinned state, clone manually into `org-plugins/`
+  and accept that `cowork-mdm marketplace update` will push it forward.

--- a/plugin/skills/mdm-profile-authoring/SKILL.md
+++ b/plugin/skills/mdm-profile-authoring/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: mdm-profile-authoring
+description: Authoring Claude Desktop Managed Preferences profiles — selecting the right inference provider (Bedrock, Vertex, Azure Foundry, generic gateway, or MCP-only), looking up schema keys, writing a profile YAML, generating .mobileconfig or .plist, and validating the result. Load when the user wants to create, edit, or inspect a Claude Desktop MDM config — phrases like "write a mobileconfig", "configure Bedrock/Vertex/Azure for Claude", "lock down MCP servers", "what keys are available", "profile new", "profile validate", or questions about specific MDM keys like inferenceProvider, inferenceModels, managedMcpServers, coworkEgressAllowedHosts.
+---
+
+# MDM profile authoring
+
+This skill covers **creating and validating** a Claude Desktop MDM profile.
+For deploying the profile to real hosts, switch to `mdm-profile-deploy`.
+
+## The schema in 30 seconds
+
+Claude Desktop reads ~51 MDM keys from a managed plist (macOS) or registry
+(Windows). Anthropic documents 8 publicly; `cowork-mdm` embeds the full set
+extracted from the Electron bundle's zod schema.
+
+Every key has a **type** (`string`, `bool`, `integer`, `stringArray`,
+`jsonString`), a **scope** (`3p`, `3p-bootstrap`, …), and an `appMin`
+(minimum Claude Desktop version that reads it). Two quirks to internalize:
+
+- **`stringArray`** — plain list of strings. The YAML side accepts either a
+  native list or a JSON-array-in-a-string (`'["a","b"]'`); the CLI coerces
+  to `[]string` at load time. Keys of this type include `inferenceModels`
+  and `coworkEgressAllowedHosts`. On disk they render as `<string>` entries
+  wrapping a JSON array (that's how the live Claude Desktop app stores them
+  too — do not try to "fix" this into a plist `<array>`).
+- **`jsonString`** — keys typed as *a string whose contents are valid JSON
+  of a specific inner shape*. The plist holds a single `<string>`; the app
+  JSON-parses it at read time. `managedMcpServers` is the big one. When
+  hand-editing, the inner JSON must stay a single line and be valid.
+
+When in doubt, `cowork-mdm schema show <key> --json` tells you the exact
+type and example. Do not guess a key's type from its name — `inferenceModels`
+is `stringArray`, not `jsonString`.
+
+> **Safety**: this skill only **authors** profiles. Do not `sudo`, do not
+> write to `/Library/Managed Preferences/`, and do not run
+> `cowork-mdm profile apply` without `--dry-run` on the user's behalf. If
+> the user pivots from "write this profile" to "now apply it", hand off
+> to the `mdm-profile-deploy` skill — it enshrines the MDM-channel rule.
+
+## Canonical authoring workflow
+
+```
+1. schema list [--json]                 # orient (--json is stable, table output is for humans)
+2. schema show <key> [--json]           # drill into each key
+3. profile templates                    # pick a starter
+4. Write overrides.yaml                 # your enterprise values (secrets here, NOT in template dir)
+5. profile new --template X --from overrides.yaml --out out.mobileconfig
+6. profile validate out.mobileconfig    # gate — succeeds silently, fails loud with exit 1
+```
+
+`profile validate` prints `FILE: OK (N keys)` on success; on failure it
+prints the offending key and exits non-zero. The output is human-readable
+text, not JSON — for programmatic checks, rely on the exit code.
+
+**Never edit the template files under the repo.** They're shipped in the
+binary and are meant to be provider-neutral scaffolds. Enterprise-specific
+values (ARNs, MCP tokens, allowed-host lists) belong in a **user YAML file**
+that stays private.
+
+## The five built-in templates
+
+`cowork-mdm profile templates` prints the current list. As of v0.3:
+
+| Template | Inference provider | Typical customization |
+| --- | --- | --- |
+| `bedrock-basic` | AWS Bedrock via `~/.aws` | `inferenceBedrockRegion`, `inferenceBedrockProfile`, `inferenceModels` (ARN `stringArray`) |
+| `vertex` | Google Vertex AI | project id, region, model IDs |
+| `foundry` | Azure Foundry | endpoint, deployment names |
+| `gateway` | Generic OpenAI-compatible gateway (LLM proxy) | base URL, auth header, model list |
+| `mcp-only` | No inference override, only locks MCP + egress | `managedMcpServers`, `coworkEgressAllowedHosts` |
+
+## Overrides YAML shape
+
+The `--from` file uses the same structure as a template:
+
+```yaml
+name: my-org-bedrock        # used as PayloadDisplayName in mobileconfig
+description: |
+  Optional. Shown in MDM UIs.
+values:
+  inferenceProvider: bedrock
+  inferenceBedrockRegion: us-west-2
+  inferenceBedrockProfile: default
+  inferenceBedrockAwsDir: /Users/{user}/.aws   # or leave default
+  # stringArray keys: either a YAML list or a JSON-array-as-string work.
+  # The CLI coerces both to []string. The live Claude Desktop app stores
+  # these on disk as <string>["..."]</string>, so don't be surprised.
+  inferenceModels: >-
+    ["arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/OPUS_ID","arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/SONNET_ID[1m]","arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/HAIKU_ID"]
+  coworkEgressAllowedHosts: '["*.internal.example.com","api.example.com"]'
+  # jsonString key: must be a valid-JSON string of the shape the schema
+  # describes (object array with name/url/transport/toolPolicy/...).
+  managedMcpServers: >-
+    [{"name":"jira","url":"https://mcp.example.com/jira","transport":"http"}]
+  disableDeploymentModeChooser: true
+```
+
+Key points:
+
+- YAML `>-` ("folded, strip") joins wrapped lines into a single string
+  without a trailing newline. Use it for long inline JSON.
+- Booleans go raw (`true` / `false`), not quoted.
+- Overrides **replace** the template's value for that key; templates and
+  overrides merge at the key level.
+
+## The `[1m]` suffix on Bedrock ARNs
+
+Some Bedrock accounts are entitled to 1M-token context variants of a model.
+The app detects these by the `[1m]` suffix inside the last path segment of
+the ARN:
+
+```
+…inference-profile/v37lj7n5l53w[1m]
+```
+
+If you're **not** entitled, include the base ARN without the suffix. If you
+are, the suffix gives users a 1M-context picker entry.
+
+## Generating and validating
+
+```bash
+cowork-mdm profile new \
+  --template bedrock-basic \
+  --from overrides.yaml \
+  --out /tmp/cowork.mobileconfig
+
+cowork-mdm profile validate /tmp/cowork.mobileconfig
+```
+
+`profile validate` checks:
+
+- every key exists in the embedded schema (no typos);
+- every value matches its key's type (no `boolean` in a `string` slot);
+- `jsonString` keys contain parseable JSON of the declared inner shape.
+
+If validation fails, the message tells you the offending key. Fix the YAML,
+regenerate, re-validate.
+
+## Round-trip: reading an existing profile
+
+There is no `profile decode` subcommand yet. For v0.3, the easiest round-
+trip check is to **apply the authored profile to the host (or any test
+host) and read it back with `cowork-mdm profile status --json`**. That
+command decodes the live plist into `profile.values` — compare that
+key/value map against the YAML you authored.
+
+## Quick provider recipes
+
+### Bedrock (most common for 3p deployments)
+
+```yaml
+values:
+  inferenceProvider: bedrock
+  inferenceBedrockRegion: us-west-2
+  inferenceBedrockProfile: default
+  inferenceModels: >-
+    ["arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/OPUS","arn:aws:bedrock:us-west-2:ACCOUNT:application-inference-profile/SONNET[1m]"]
+  disableDeploymentModeChooser: true
+```
+
+### Vertex AI
+
+```yaml
+values:
+  inferenceProvider: vertex
+  inferenceVertexProjectId: my-gcp-project
+  inferenceVertexRegion: us-central1
+  inferenceModels: >-
+    ["claude-opus-4-7@20260101","claude-sonnet-4-6@20260101"]
+  disableDeploymentModeChooser: true
+```
+
+(Double-check field names with `cowork-mdm schema list --json | jq
+'.[].name' | grep -i vertex` — Vertex has several adjacent keys like
+`inferenceVertexCredentialsFile`, `inferenceVertexOAuthClientId`, etc.)
+
+### Locked-down MCP + egress without overriding inference
+
+```yaml
+values:
+  managedMcpServers: >-
+    [{"name":"confluence","url":"https://mcp.internal/confluence","transport":"http"}]
+  coworkEgressAllowedHosts: '["*.internal.example.com"]'
+```
+
+Always confirm the exact field names with `schema show` before shipping — the
+zod schema is the source of truth, not this document.
+
+## Gotchas
+
+- **`coworkEgressAllowedHosts` is a `stringArray`** (per the zod schema),
+  but the live Claude Desktop plist stores it on disk as a single
+  `<string>` wrapping a JSON array. The CLI emits whichever shape matches
+  the app's actual behavior; don't try to "normalize" it yourself. `["*"]`
+  means "allow everything."
+- **`inferenceBedrockAwsDir` is absolute, per-user**. Either set a fixed
+  path (`/Users/<user>/.aws`) and accept that only that user's machine
+  works, or leave it unset and let Claude Desktop default to `~/.aws`.
+- **MCP tokens in `managedMcpServers` are readable by anyone with plist
+  read access.** They belong in overrides, not the shared template dir, and
+  if your threat model cares, rotate via MDM push rather than embedding.
+- **`profile new --format plist` emits deterministic bytes.** Same inputs,
+  same bytes — verified to byte-match the live maintainer plist after
+  plutil normalization. The `mobileconfig` format does NOT: it includes a
+  fresh `PayloadUUID` per run. Compare decoded key/value sets via
+  `plutil -convert json` (or `cowork-mdm profile status`) rather than raw
+  bytes when validating round-trip.

--- a/plugin/skills/mdm-profile-deploy/SKILL.md
+++ b/plugin/skills/mdm-profile-deploy/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: mdm-profile-deploy
+description: Deploying a Claude Desktop MDM profile to real user machines — choosing between MDM channel push (Jamf/Intune/Kandji/Mosyle) vs local apply, verifying status on a target host, and debugging profiles that don't take effect. Load when the user wants to push, install, activate, or verify an already-authored profile — phrases like "apply this mobileconfig", "push via Jamf/Intune", "profile status", "why isn't my config taking effect", "Claude Desktop isn't reading my settings", or anything about `/Library/Managed Preferences/`.
+---
+
+# MDM profile deploy
+
+This skill covers **pushing an already-authored profile to hosts** and
+**verifying it took effect**. For authoring, see `mdm-profile-authoring`.
+
+## The single most important rule (read this first)
+
+> **Direct writes to `/Library/Managed Preferences/` are CLOBBERED by
+> `managedappconfigd` on the next MDM sync.**
+
+macOS's `managedappconfigd` owns that directory. It rewrites it every time
+the system checks in with its MDM profile source. If you `sudo cp` a plist
+there:
+
+- It works **for a few hours** (or until next sync, reboot, or network
+  bounce).
+- Then macOS silently overwrites or deletes it.
+- The user reports "Claude forgot its config" and you can't reproduce it
+  because by then it's gone.
+
+**Production deployments must go through an MDM channel.** Period. The
+correct artifact to hand the IT admin is a signed `.mobileconfig`, not a
+plist and not a shell command.
+
+Local `apply` exists only for **developer loops on a dev machine** — and
+even then, `--dry-run` is almost always what you want.
+
+## Deployment paths (pick one)
+
+### Path A — MDM channel (the production path)
+
+1. Generate a `.mobileconfig` with `cowork-mdm profile new … --out profile.mobileconfig`.
+2. Validate: `cowork-mdm profile validate profile.mobileconfig`.
+3. Hand the signed / unsigned `.mobileconfig` to the IT admin for upload:
+   - **Jamf Pro** — Computers → Configuration Profiles → Upload → scope to
+     a smart group / target machines.
+   - **Intune** — Devices → Configuration profiles → Create → macOS →
+     Templates → Custom → upload.
+   - **Kandji / Mosyle / Addigy** — their "Custom Profile" workflow.
+4. The MDM server pushes the profile; `managedappconfigd` writes the plist
+   into `/Library/Managed Preferences/…` and **keeps it there**.
+5. Verify on a target host with `cowork-mdm profile status` (next section).
+
+### Path B — Local apply (dev loop only, not production)
+
+`cowork-mdm profile apply` writes the plist directly. Use only to iterate
+on a profile on your own machine:
+
+```bash
+sudo cowork-mdm profile apply profile.mobileconfig --dry-run
+# inspect the preview, then:
+sudo cowork-mdm profile apply profile.mobileconfig
+```
+
+Two safety rails:
+
+- **Always run `--dry-run` first** and confirm the preview matches intent.
+- **Never invoke `sudo` on the user's behalf** — hand them the command,
+  let them run it. This plugin has no business elevating.
+
+If the user asks you to `sudo apply` in production, push back with the rule
+above and offer to hand them a `.mobileconfig` instead.
+
+## Verifying status
+
+`cowork-mdm profile status` reads the active plist / registry key and
+reports what's currently live.
+
+Human output:
+
+```
+platform: darwin
+target:   /Library/Managed Preferences/com.anthropic.claudefordesktop.plist
+present:  yes
+keys:     8
+unknown:  0
+```
+
+JSON output (parse this to reason programmatically):
+
+```bash
+cowork-mdm profile status --json
+```
+
+Fields: `platform`, `targetPath`, `present`, `profile.values[]` (decoded key
+set), `unknownKeys[]` (keys in the plist that `cowork-mdm`'s embedded schema
+doesn't recognize — usually a sign the host is newer than your CLI).
+
+### "I pushed but status says not present"
+
+- The profile payload type must be `com.anthropic.claudefordesktop` (the
+  app's bundle identifier). Intune/Jamf upload flows sometimes let you pick
+  wrong payload identifiers.
+- After MDM push, macOS needs a check-in. `sudo profiles renew -type
+  configuration` forces it.
+- `cowork-mdm doctor` includes `plist.exists` and `plist.schema` checks
+  — switch to `mdm-doctor` skill for the full decision tree.
+
+### "Profile is present but Claude Desktop ignores it"
+
+- Claude Desktop only reads MDM config at **launch**. Fully quit
+  (`cmd-Q`, not just close-window) and relaunch.
+- Verify the `appMin` of each key with `cowork-mdm schema show KEY`. If the
+  user's Claude Desktop is older than the `appMin`, that key is silently
+  ignored.
+- Run `cowork-mdm profile status --json | jq .unknownKeys` — if any of
+  your keys show up as unknown, your plist has a typo or the schema drifted.
+
+## System-scope vs user-scope plists
+
+Claude Desktop reads both:
+
+- `/Library/Managed Preferences/com.anthropic.claudefordesktop.plist`
+  (system — applies to all users)
+- `/Library/Managed Preferences/<username>/com.anthropic.claudefordesktop.plist`
+  (per-user — overrides system for that user)
+
+Most deployments use the system plist. The per-user variant is useful when
+different groups need different `inferenceProfile` values. `cowork-mdm
+profile status` reports whichever it finds; with `--json` both surface if
+both exist.
+
+## Pre-flight checklist before any push
+
+```bash
+cowork-mdm profile validate profile.mobileconfig           # schema clean; exit 0 on success
+cowork-mdm profile apply profile.mobileconfig --dry-run    # preview exact bytes
+cowork-mdm profile status --json                           # what's already live on this host
+```
+
+If any of these three fail, do not ship.
+
+## Gotchas specific to deploy
+
+- **Rotating MCP tokens inside `managedMcpServers`** — when an MDM profile
+  is replaced by a new version, the old plist is rewritten. If you depend
+  on old tokens being invalidated, also rotate them at the provider side;
+  the plist rewrite alone doesn't clear app caches.
+- **Signed vs unsigned mobileconfigs** — `cowork-mdm profile new` emits
+  **unsigned** `.mobileconfig`. Most MDMs re-sign during upload. If you
+  need to test locally by double-click, expect a "Profile unsigned" warning
+  — that's expected, not a bug.
+- **`disableDeploymentModeChooser: true` gates hard on the provider being
+  fully configured.** If you ship this flag but `inferenceProvider` /
+  `inferenceBedrockRegion` / `inferenceBedrockProfile` are missing, users
+  hit a dead screen with no way to recover. Keep the chooser enabled until
+  you're confident the profile is complete, then flip the flag.

--- a/specs/claude-plugin.md
+++ b/specs/claude-plugin.md
@@ -1,0 +1,192 @@
+# Spec: `plugin/` — Claude Code plugin surface (v0.3)
+
+## Intent
+
+Ship `cowork-mdm` not just as a CLI binary but also as a **Claude Code plugin**
+so that an agent running inside Claude Code (Desktop or Code CLI) can drive the
+CLI on the user's behalf: generate a profile, validate it, install org plugins,
+diagnose a broken host.
+
+The plugin ships **no code** — it is a bundle of text assets (skills, slash
+commands, permission grants) that teaches an agent:
+
+1. what `cowork-mdm` is and when it applies,
+2. which subcommand to reach for in which situation,
+3. the safe sequencing of read → validate → (user-mediated) apply,
+4. the gotchas that cannot be learned from `--help` alone (e.g. the
+   `managedappconfigd` clobber trap).
+
+CLI remains the single source of truth for behavior. Plugin assets reference
+CLI subcommands by name and rely on `--json` for machine-readable output.
+
+## Non-goals
+
+- No MCP server, no custom tool protocol. The agent drives the CLI via Bash.
+- No substitute for `--help`. Skills describe **workflows**, not flag tables.
+- The plugin does not issue `sudo` on the user's behalf. Apply always stays
+  manual or MDM-channel mediated — the skill explains why.
+
+## Directory layout
+
+```
+.claude-plugin/
+  marketplace.json            # declares this repo as a single-plugin marketplace
+plugin/
+  .claude-plugin/
+    plugin.json               # plugin manifest + permission grants
+  skills/
+    cowork-mdm/SKILL.md              # thin router / index
+    mdm-profile-authoring/SKILL.md
+    mdm-profile-deploy/SKILL.md
+    mdm-plugins/SKILL.md
+    mdm-doctor/SKILL.md
+  commands/
+    new-profile.md
+    deploy.md
+    doctor.md
+    refresh-plugins.md
+```
+
+## `marketplace.json` (repo root)
+
+```json
+{
+  "name": "cowork-mdm",
+  "owner": { "name": "krislavten" },
+  "plugins": [
+    {
+      "name": "cowork-mdm",
+      "source": "./plugin",
+      "description": "Claude Desktop MDM toolkit — profile authoring, plugin marketplace, doctor."
+    }
+  ]
+}
+```
+
+Users install with:
+
+```
+/plugin marketplace add https://github.com/krislavten/cowork-mdm
+/plugin install cowork-mdm@cowork-mdm
+```
+
+## `plugin.json` (plugin root)
+
+```json
+{
+  "name": "cowork-mdm",
+  "version": "0.3.0",
+  "description": "Claude Desktop MDM: profile authoring, plugin marketplace, doctor. Requires the `cowork-mdm` CLI on PATH.",
+  "author": { "name": "krislavten" },
+  "homepage": "https://github.com/krislavten/cowork-mdm"
+}
+```
+
+- `version` must match the CLI release tag (`v0.3.0`).
+- Permission grants (`Bash(cowork-mdm:*)`) are declared per slash command
+  via the `allowed-tools:` frontmatter — the same pattern Anthropic's
+  `commit-commands` plugin uses for git. The top-level `plugin.json` has
+  no `permissions` block; adding one would override the per-command
+  scoping.
+- The CLI's own permission model (sudo for apply, sudo for writes into
+  `/Library/Application Support/Claude/`) is unchanged by any grant here
+  — the user still has to run `sudo` themselves for those operations.
+
+## Skills
+
+Five skills, each with `description` written as *"load me when …"* rather than
+*"I am …"* — Claude Code selects skills by matching the user request against
+the description.
+
+### `cowork-mdm` (router)
+
+- **When loaded**: user mentions "cowork-mdm", "Claude Desktop MDM", "managed
+  preferences for Claude", or asks a generic question before the sub-domain is
+  clear.
+- **Purpose**: 30-line index. Lists the CLI surface and routes the agent to
+  one of the four specialist skills.
+
+### `mdm-profile-authoring`
+
+- **When loaded**: user wants to *create* or *edit* an MDM profile — phrases
+  like "write a mobileconfig", "configure Bedrock / Vertex / Azure", "lock
+  down MCP servers", "pick a provider", "look up a schema key".
+- **Purpose**: the agent-facing manual for `cowork-mdm schema` + `cowork-mdm
+  profile new/validate`. Covers the 51-key landscape, the three inference
+  provider recipes, and the `--from overrides.yaml` pattern for enterprise
+  secrets. Format conversions happen via `profile new --format` — there is
+  no `profile export` subcommand.
+
+### `mdm-profile-deploy`
+
+- **When loaded**: user wants to *push* a profile to machines — phrases like
+  "apply this profile", "push via Jamf/Intune/Kandji", "why isn't my config
+  taking effect", "profile status".
+- **Purpose**: covers the `apply` / `status` lifecycle and enshrines the
+  single most important gotcha: **writing directly to
+  `/Library/Managed Preferences/` is clobbered by `managedappconfigd` on the
+  next MDM sync**. Production deployments must use an MDM channel. Agent must
+  not `sudo` apply on user's behalf.
+
+### `mdm-plugins`
+
+- **When loaded**: user wants to manage Claude Desktop's `org-plugins/`
+  directory — "install a plugin", "add a marketplace", "plugin not showing
+  up", "dangling symlink".
+- **Purpose**: the agent-facing manual for `cowork-mdm marketplace` +
+  `cowork-mdm plugin`. Explains the symlink model, the `marketplace add →
+  update → link-all → plugin list` cycle, and when `prune` is safe.
+
+### `mdm-doctor`
+
+- **When loaded**: user is troubleshooting a broken Claude Desktop install or
+  unclear config state — "Claude won't launch", "doctor", "why isn't my
+  profile active", "diagnose this host".
+- **Purpose**: reverse workflow (symptom → probable cause → command). Reads
+  `cowork-mdm doctor --json`, interprets each check, proposes the next step.
+
+## Slash commands
+
+Slash commands are **executable playbooks** — they tell the agent what to do
+in what order, not what the CLI flags are. The CLI is the source of truth for
+flags; the command body calls out to CLI subcommands.
+
+### `/cowork-mdm:new-profile`
+
+Interactive: ask the user which inference provider (Bedrock / Vertex / Azure /
+Gateway / MCP-only), fetch the matching template, prompt for the
+enterprise-specific values, emit a `overrides.yaml`, then run
+`cowork-mdm profile new --template X --from overrides.yaml --out out.mobileconfig`,
+and finally `profile validate` the output.
+
+### `/cowork-mdm:deploy PATH`
+
+Validate → show decoded key table → dry-run `profile apply --dry-run` to
+preview the plist → **stop and hand off** with instructions for MDM-channel
+deployment. Never invokes sudo.
+
+### `/cowork-mdm:doctor`
+
+Run `cowork-mdm doctor --json`, parse, group findings by severity, suggest
+`--fix` only for checks whose JSON result has `fixAvailable: true`,
+explain each warning.
+
+### `/cowork-mdm:refresh-plugins`
+
+`marketplace update` (all repos) → `plugin list --json` → show diff from the
+previous state → `plugin prune` dry-run → ask before committing the prune.
+
+## Testing
+
+End-to-end acceptance test: on the maintainer's own Mac, run
+`/cowork-mdm:new-profile` against the live `/Library/Managed Preferences/...`
+plist and confirm the generated plist round-trips to the same key set (modulo
+whitespace). This is the v0.3 gate — if the plugin can't reproduce the
+maintainer's own config, it won't work on customer hosts either.
+
+## Release
+
+- Plugin version field in `plugin.json` and `marketplace.json` entries tracks
+  the CLI release tag (both bumped to `0.3.0` at release time).
+- No separate CI workflow — plugin assets ship in the repo root; installing is
+  `git clone`-based.


### PR DESCRIPTION
## Summary

Ships cowork-mdm as a Claude Code plugin: five skills + four slash commands that teach an agent how to drive the existing CLI (profile authoring, marketplace management, diagnostics) on the user's behalf. **No CLI code changes** — all assets are markdown/JSON.

- **Skills** (triggered by user intent): `cowork-mdm` (router), `mdm-profile-authoring`, `mdm-profile-deploy`, `mdm-plugins`, `mdm-doctor`.
- **Slash commands**: `/cowork-mdm:new-profile`, `/cowork-mdm:deploy PATH`, `/cowork-mdm:doctor`, `/cowork-mdm:refresh-plugins`.
- **Safety invariants** enforced across every asset: never sudo, never direct-write to `/Library/Managed Preferences/` (managedappconfigd clobber), production deploys go through an MDM channel.

Install flow (for release):

\`\`\`
/plugin marketplace add https://github.com/krislavten/cowork-mdm
/plugin install cowork-mdm@cowork-mdm
\`\`\`

See `specs/claude-plugin.md` for design rationale.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all 8 internal packages + cli green
- [x] **Round-trip verification on maintainer's Mac**: reconstructed `overrides.yaml` from live `/Library/Managed Preferences/com.anthropic.claudefordesktop.plist`, ran `cowork-mdm profile new --format plist` — plutil-normalized JSON diff vs live plist = **IDENTICAL** (1093 bytes each)
- [x] `marketplace list` + `plugin list --json` enumerate the live host state exactly (2 marketplaces, 53 plugins, 0 dangling)
- [x] `/codex:rescue` review — APPROVE after two correction rounds (schema type claims, doctor JSON shape, plugin list field casing, mobileconfig non-determinism)
- [ ] Install the plugin in a fresh Claude Code session and confirm skills load on the expected prompts
- [ ] Exercise `/cowork-mdm:new-profile` interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)