### PR TITLE
docs(plugin): fix v0.3 skill gaps surfaced by subagent tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ cowork-mdm paths show                      # host paths cowork-mdm reads
 cowork-mdm paths show --os windows         # simulate a different platform
 
 # Profile authoring (YAML → .mobileconfig / plist)
+# --template and --from are mutually exclusive; pick one:
 cowork-mdm profile templates
-cowork-mdm profile new --template bedrock-basic --from overrides.yaml --out my.mobileconfig
+cowork-mdm profile new --template bedrock-basic --out my.mobileconfig  # built-in verbatim
+cowork-mdm profile new --from overrides.yaml --out my.mobileconfig     # your own YAML
 cowork-mdm profile validate my.mobileconfig
 cowork-mdm profile status                  # what's currently active on this host
 

--- a/plugin/skills/cowork-mdm/SKILL.md
+++ b/plugin/skills/cowork-mdm/SKILL.md
@@ -13,24 +13,31 @@ wrapper around `cowork-mdm` invocations.
 ## Pre-flight: the CLI must be on PATH
 
 ```bash
-cowork-mdm --version  # → 0.3.0 (commit ..., built ...)
+cowork-mdm --version
 ```
 
-If this fails, stop and tell the user to install it:
+Expected output is a single line starting with `cowork-mdm version`,
+followed by either a released tag (e.g. `0.3.0 (commit abc1234, built
+2026-05-01)`) **or** the string `dev (commit none, built unknown)` on a
+developer-built binary. Both are valid — the plugin works against either.
+Only treat this as broken if the command is not found or exits non-zero.
+
+If it fails with "command not found" or equivalent, stop and tell the
+user to install it:
 
 ```bash
 brew install krislavten/tap/cowork-mdm
 # or download a binary from https://github.com/krislavten/cowork-mdm/releases
 ```
 
-Do not try to work around a missing CLI. The plugin cannot do anything useful
-without it.
+Do not try to work around a missing CLI. The plugin cannot do anything
+useful without it.
 
 ## Pick a sub-skill by task
 
 | User wants to … | Load sub-skill | Typical commands |
 | --- | --- | --- |
-| Look up a Managed Preferences key, draft / edit a profile for Bedrock/Vertex/Azure/Gateway/MCP-only | **mdm-profile-authoring** | `schema list`, `schema show KEY`, `profile templates`, `profile new --template … --from …`, `profile validate` |
+| Look up a Managed Preferences key, draft / edit a profile for Bedrock/Vertex/Azure/Gateway/MCP-only | **mdm-profile-authoring** | `schema list`, `schema show KEY`, `profile templates`, `profile new --template NAME` OR `profile new --from overrides.yaml` (mutually exclusive), `profile validate` |
 | Push an existing profile to real hosts; investigate why it isn't taking effect | **mdm-profile-deploy** | `profile apply --dry-run`, `profile status` |
 | Install / update / remove org plugin marketplaces; clean dangling symlinks | **mdm-plugins** | `marketplace add/list/update/remove`, `plugin list/show/prune` |
 | Diagnose a specific user's broken Claude Desktop install | **mdm-doctor** | `paths show`, `doctor`, `doctor --fix`, `doctor --json` |

--- a/plugin/skills/mdm-doctor/SKILL.md
+++ b/plugin/skills/mdm-doctor/SKILL.md
@@ -47,6 +47,10 @@ Key fields to parse:
   `orgplugins.dangling`, `marketplace.repos-operable`, `user.sessions`,
   `git.available`).
 - `results[].status` — one of `ok` / `warning` / `error` / `skipped`.
+- `results[].message` — short human string; **may be absent** on `ok` or
+  `skipped` results (omitempty). Guard your access.
+- `results[].detail` — optional longer explanation; **omitempty**, often
+  absent. Only read it after checking existence.
 - `results[].fixAvailable` — boolean; `--fix` only attempts to repair
   checks where this is true.
 - `summary` — counts by status. Fast path: if `summary.ok == summary.total`
@@ -152,6 +156,15 @@ Returns the exact paths `cowork-mdm` is consulting. The JSON uses
 **PascalCase** field names — `ClaudeAppPath`, `ManagedPrefsPlist`,
 `ManagedPrefsUserPlist(<you>)`, `OrgPluginsDir`, `UserSessionsDir`,
 `LaunchAgentDir`, `WindowsRegistryPath`. Parse with those exact keys.
+
+**Watch out**: the key `ManagedPrefsUserPlist(<you>)` contains a literal
+`<you>` placeholder — the CLI does not substitute the username into the
+key name itself (only into the value). Don't regex-rewrite the key; read
+it verbatim. Example jq:
+
+```bash
+cowork-mdm paths show --json | jq '.["ManagedPrefsUserPlist(<you>)"]'
+```
 
 If the user has customized any of these (e.g. Parallels/VDI installs where
 `/Library/Application Support/Claude/` is bind-mounted elsewhere), the

--- a/plugin/skills/mdm-plugins/SKILL.md
+++ b/plugin/skills/mdm-plugins/SKILL.md
@@ -70,6 +70,53 @@ All commands that mutate `org-plugins/` require write access to
 `/Library/Application Support/Claude/` — in practice, `sudo`. The plugin
 never `sudo`s for you.
 
+### `marketplace list --json` and `plugin list --json` field schemas
+
+Both commands emit PascalCase fields — parse with exact casing.
+
+`marketplace list --json` returns an array of:
+
+```
+{
+  "Name":       string,       // basename of clone (e.g. "claude-plugins-official")
+  "URL":        string,       // git remote URL
+  "Path":       string,       // absolute clone path under org-plugins/
+  "Plugins":    [string, ...],// plugin names discovered inside this marketplace
+  "CurrentRef": string,       // short SHA of HEAD — this is the "HEAD" column in human output
+  "LastPull":   string        // RFC3339 timestamp; "0001-01-01T00:00:00Z" == never pulled (fresh clone)
+}
+```
+
+The human table's `HEAD` / `PLUGINS` / `LAST-PULL` columns correspond to
+the JSON fields `CurrentRef` / `len(Plugins)` / `LastPull`. The field
+names differ — don't jq on the human column names.
+
+`plugin list --json` returns an array of:
+
+```
+{
+  "Name":       string,       // top-level entry name
+  "Source":     string,       // see "Source values" below
+  "TargetPath": string,       // what the symlink points at (or the real dir path)
+  "IsSymlink":  bool,
+  "Dangling":   bool,
+  "Manifest":   {"name","version","description","author"} | null
+}
+```
+
+**Source values** (enum):
+- `marketplace:<name>` — top-level symlink pointing into a managed
+  marketplace's `plugins/` or `external_plugins/` subdir. This is the
+  normal case.
+- `local-directory` — a real directory at the top level of `org-plugins/`.
+  **This includes the marketplace clone directories themselves.** That is,
+  `plugin list` will show `claude-plugins-official` and `rush-plugin` as
+  entries in addition to the symlinks under them. Expect `len(plugin list)
+  == len(marketplace list) + total symlinks`. Claude Desktop treats these
+  "container" entries as no-op plugins (no manifest), so it's not a bug,
+  but when you report "plugin count" to a user, subtract the marketplace
+  count.
+
 ## Canonical workflow: install the official marketplace
 
 ```bash
@@ -105,9 +152,8 @@ cowork-mdm marketplace add https://github.com/example/claude-plugins
 cowork-mdm plugin list --json | jq '.[] | select(.Source | contains("example"))'
 ```
 
-`plugin list --json` uses PascalCase fields: `Name`, `Source` (e.g.
-`marketplace:claude-plugins-official`), `TargetPath`, `IsSymlink`,
-`Dangling`, `Manifest`. Parse with those exact keys.
+See the field-schema block above for the full shape of both `--json`
+endpoints.
 
 No per-plugin install step exists — adding a marketplace auto-links every
 plugin inside it. If you want to un-expose one plugin, `plugin unlink NAME`

--- a/plugin/skills/mdm-profile-authoring/SKILL.md
+++ b/plugin/skills/mdm-profile-authoring/SKILL.md
@@ -45,8 +45,8 @@ is `stringArray`, not `jsonString`.
 1. schema list [--json]                 # orient (--json is stable, table output is for humans)
 2. schema show <key> [--json]           # drill into each key
 3. profile templates                    # pick a starter
-4. Write overrides.yaml                 # your enterprise values (secrets here, NOT in template dir)
-5. profile new --template X --from overrides.yaml --out out.mobileconfig
+4. Write overrides.yaml                 # your YAML — see "Overrides YAML shape" below
+5. profile new --from overrides.yaml --out out.mobileconfig
 6. profile validate out.mobileconfig    # gate — succeeds silently, fails loud with exit 1
 ```
 
@@ -54,10 +54,33 @@ is `stringArray`, not `jsonString`.
 prints the offending key and exits non-zero. The output is human-readable
 text, not JSON — for programmatic checks, rely on the exit code.
 
-**Never edit the template files under the repo.** They're shipped in the
-binary and are meant to be provider-neutral scaffolds. Enterprise-specific
-values (ARNs, MCP tokens, allowed-host lists) belong in a **user YAML file**
-that stays private.
+### `--template` vs `--from` are mutually exclusive
+
+`profile new` accepts **either** `--template NAME` (use a built-in template
+verbatim) **or** `--from FILE` (use your own YAML). You cannot combine them
+on the same invocation — `cowork-mdm profile new --template X --from Y`
+errors out.
+
+Idiomatic paths:
+
+- **Template verbatim** — `profile new --template bedrock-basic --out out.mobileconfig`.
+  Emits the template as-is. Useful to preview the default shape, or pipe
+  through `--set KEY=VALUE` flags for small tweaks.
+- **Your own YAML** (recommended for enterprise use) — write your own
+  `overrides.yaml` following the same schema as the built-in templates
+  (see next section), then `profile new --from overrides.yaml`. This is
+  what you want when you have enterprise-specific values (ARNs, tokens)
+  that should not live in the repo.
+
+To start from a built-in template and customize it, **copy** one of the
+files under `internal/profile/templates/<name>.yaml` in the cowork-mdm
+source into your own `overrides.yaml`, edit freely, and pass with `--from`.
+The built-in templates are not a base layer — there is no merge step.
+
+**Never edit the template files inside the cowork-mdm repo.** They're
+shipped in the binary and are meant to be provider-neutral scaffolds.
+Enterprise-specific values (ARNs, MCP tokens, allowed-host lists) belong
+in your private `overrides.yaml`.
 
 ## The five built-in templates
 
@@ -102,8 +125,12 @@ Key points:
 - YAML `>-` ("folded, strip") joins wrapped lines into a single string
   without a trailing newline. Use it for long inline JSON.
 - Booleans go raw (`true` / `false`), not quoted.
-- Overrides **replace** the template's value for that key; templates and
-  overrides merge at the key level.
+- The `--from` YAML is the **complete** input to `profile new`. It is not
+  an overlay on a built-in template — no merge step happens. If you want
+  template defaults as a starting point, copy the template file's contents
+  into your YAML, then edit. The only live override mechanism on the CLI
+  is the `--set KEY=VALUE` flag, which can be combined with `--template`
+  or `--from`.
 
 ## The `[1m]` suffix on Bedrock ARNs
 
@@ -122,7 +149,6 @@ are, the suffix gives users a 1M-context picker entry.
 
 ```bash
 cowork-mdm profile new \
-  --template bedrock-basic \
   --from overrides.yaml \
   --out /tmp/cowork.mobileconfig
 

--- a/plugin/skills/mdm-profile-deploy/SKILL.md
+++ b/plugin/skills/mdm-profile-deploy/SKILL.md
@@ -69,17 +69,9 @@ above and offer to hand them a `.mobileconfig` instead.
 ## Verifying status
 
 `cowork-mdm profile status` reads the active plist / registry key and
-reports what's currently live.
-
-Human output:
-
-```
-platform: darwin
-target:   /Library/Managed Preferences/com.anthropic.claudefordesktop.plist
-present:  yes
-keys:     8
-unknown:  0
-```
+reports what's currently live. The JSON form is the source of truth for
+the field contract; the human form is a rendering for eyeballs and may
+omit fields that are absent / null.
 
 JSON output (parse this to reason programmatically):
 
@@ -87,9 +79,29 @@ JSON output (parse this to reason programmatically):
 cowork-mdm profile status --json
 ```
 
-Fields: `platform`, `targetPath`, `present`, `profile.values[]` (decoded key
-set), `unknownKeys[]` (keys in the plist that `cowork-mdm`'s embedded schema
-doesn't recognize — usually a sign the host is newer than your CLI).
+Shape:
+
+```
+{
+  "platform":    "darwin" | "windows",
+  "targetPath":  string,                      // plist path or registry key
+  "present":     bool,
+  "profile": {
+    "name":   string,                         // "" when decoded from an on-disk plist
+    "values": { "<key>": <value>, ... }       // map, NOT array — jq with .profile.values["KEY"]
+  },
+  "unknownKeys": [ {"key":"…","raw":"…"}, ... ] | null,
+  "parseError":  string                       // "" when parse succeeded
+}
+```
+
+Notes that bite parsers:
+- `profile.values` is a **JSON object** (map keyed by preference name),
+  not an array. Access with `jq '.profile.values.inferenceProvider'`.
+- `unknownKeys` is `null` when there are none, not `[]`. Guard with
+  `jq '.unknownKeys // [] | length'`.
+- The human-output table **does not** include an `unknown: 0` line — only
+  `unknownKeys` in JSON carries that data.
 
 ### "I pushed but status says not present"
 
@@ -108,8 +120,9 @@ doesn't recognize — usually a sign the host is newer than your CLI).
 - Verify the `appMin` of each key with `cowork-mdm schema show KEY`. If the
   user's Claude Desktop is older than the `appMin`, that key is silently
   ignored.
-- Run `cowork-mdm profile status --json | jq .unknownKeys` — if any of
-  your keys show up as unknown, your plist has a typo or the schema drifted.
+- Check `unknownKeys`: `cowork-mdm profile status --json | jq '.unknownKeys
+  // []'`. A non-empty list means your plist has a typo or the schema
+  drifted; `null` or `[]` is clean.
 
 ## System-scope vs user-scope plists
 

--- a/specs/claude-plugin.md
+++ b/specs/claude-plugin.md
@@ -154,10 +154,13 @@ flags; the command body calls out to CLI subcommands.
 ### `/cowork-mdm:new-profile`
 
 Interactive: ask the user which inference provider (Bedrock / Vertex / Azure /
-Gateway / MCP-only), fetch the matching template, prompt for the
-enterprise-specific values, emit a `overrides.yaml`, then run
-`cowork-mdm profile new --template X --from overrides.yaml --out out.mobileconfig`,
-and finally `profile validate` the output.
+Gateway / MCP-only), use the matching built-in template as a structural
+reference, prompt the user for enterprise-specific values, author an
+`overrides.yaml` in that shape, then run `cowork-mdm profile new
+--from overrides.yaml --out out.mobileconfig` — without `--template`, since
+the two flags are mutually exclusive. Finally run `profile validate` on
+the output. Format conversions go through `profile new --format`; there
+is no `profile export` subcommand.
 
 ### `/cowork-mdm:deploy PATH`
 


### PR DESCRIPTION
## Summary

Follow-up to #26. Ran 4 subagent tests (one per specialist skill: authoring, deploy, doctor, plugins) to validate the skills are self-sufficient when an agent reads only the plugin's SKILL.md files + cowork-mdm --help. Each subagent attempted a realistic task without prior context.

Findings + fixes:

**MUST-FIX**
- Authoring skill's canonical workflow showed `profile new --template X --from Y` — these flags are **mutually exclusive** in the CLI. Rewrote to show them as two separate paths (template-verbatim vs own-YAML), clarified `--from` is the complete input (no merge step).
- Router skill's `--version` preflight expected literal `0.3.0`; dev builds print `dev (commit none, built unknown)` and a strict agent would stop on a perfectly good build.

**SHOULD-FIX**
- Plugins skill didn't document `marketplace list --json` field schema (`CurrentRef` ≠ human "HEAD" column, `Plugins` is array not count, `LastPull` RFC3339), didn't mention `Source: local-directory` enum, didn't warn that marketplace clone dirs occupy `plugin list` entries too.
- Deploy skill described `profile.values` as array; actually map. Included non-existent `unknown: 0` human-output line. `unknownKeys` is `null` on clean host, not `[]`.
- Doctor skill should note `message`/`detail` are omitempty; `ManagedPrefsUserPlist(<you>)` contains literal `<you>` (no username substitution).

## Test plan

- [x] `go build ./... && go test ./...` — all 8 packages green
- [x] Re-ran the authoring scenario's new recipe (`profile new --from ... --out ...` without `--template`) — emits valid 1509-byte `.mobileconfig`, `profile validate` OK (5 keys)
- [x] Spot-checked `marketplace list --json`, `plugin list --json`, `profile status --json`, `paths show --json` field names against live CLI output — all match new docs
- [x] `/codex:rescue` review — APPROVE after one correction round (caught stale "templates and overrides merge" bullet contradicting the new design)
- [ ] Re-install plugin via `/plugin marketplace add` + re-run the same 4 scenarios, confirm no subagent hits the same blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)