### PR TITLE
feat(skill): add skill pack for MDM delivery of company skills

### DIFF
--- a/cmd/cowork-mdm/cli/newcmds_test.go
+++ b/cmd/cowork-mdm/cli/newcmds_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -62,5 +65,83 @@ func TestPluginList_OnHostEmpty(t *testing.T) {
 	}
 	if !strings.Contains(out, "no plugins") && !strings.Contains(out, "NAME") {
 		t.Errorf("unexpected plugin list output: %s", out)
+	}
+}
+
+func TestSkillHelp_Mentions(t *testing.T) {
+	out, _, err := runCmd(t, "skill", "--help")
+	if err != nil {
+		t.Fatalf("skill --help: %v", err)
+	}
+	if !strings.Contains(out, "pack") {
+		t.Errorf("skill help missing 'pack' subcommand: %s", out)
+	}
+}
+
+func TestSkillPackHelp_RequiredFlags(t *testing.T) {
+	out, _, err := runCmd(t, "skill", "pack", "--help")
+	if err != nil {
+		t.Fatalf("skill pack --help: %v", err)
+	}
+	for _, want := range []string{"--name", "--out", "--version", "--force"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("skill pack help missing flag %q", want)
+		}
+	}
+}
+
+func TestSkillPack_HappyPath(t *testing.T) {
+	in := t.TempDir()
+	skillDir := filepath.Join(in, "hello")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: hello\ndescription: says hi\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "bundle")
+
+	stdout, _, err := runCmd(t, "skill", "pack", in,
+		"--name", "hello-skills",
+		"--out", out,
+		"--json",
+	)
+	if err != nil {
+		t.Fatalf("skill pack failed: %v", err)
+	}
+	var res struct {
+		BundleDir string `json:"BundleDir"`
+		Skills    []struct {
+			Name string `json:"Name"`
+		} `json:"Skills"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		t.Fatalf("skill pack --json output not JSON: %v\n%s", err, stdout)
+	}
+	if len(res.Skills) != 1 || res.Skills[0].Name != "hello" {
+		t.Errorf("unexpected skills: %+v", res.Skills)
+	}
+	if _, err := os.Stat(filepath.Join(out, ".claude-plugin", "plugin.json")); err != nil {
+		t.Errorf("plugin.json not produced: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "skills", "hello", "SKILL.md")); err != nil {
+		t.Errorf("skill not copied into bundle: %v", err)
+	}
+}
+
+func TestSkillPack_RejectsInvalidName(t *testing.T) {
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "s"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(in, "s", "SKILL.md"),
+		[]byte("---\nname: s\ndescription: d\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "bundle")
+	_, _, err := runCmd(t, "skill", "pack", in, "--name", "BadName", "--out", out)
+	if err == nil {
+		t.Error("skill pack with invalid name should fail")
 	}
 }

--- a/cmd/cowork-mdm/cli/root.go
+++ b/cmd/cowork-mdm/cli/root.go
@@ -7,6 +7,7 @@
 //	cowork-mdm profile templates / new / validate / apply / status
 //	cowork-mdm marketplace add / list / update / remove / link
 //	cowork-mdm plugin list / show / unlink / prune
+//	cowork-mdm skill pack
 //	cowork-mdm doctor [--fix] [--json]
 //	cowork-mdm --version
 package cli
@@ -63,6 +64,7 @@ func NewRootCommand(info BuildInfo, stdout, stderr io.Writer) *cobra.Command {
 	root.AddCommand(newProfileCommand(stdout, stderr))
 	root.AddCommand(newMarketplaceCommand(stdout, stderr))
 	root.AddCommand(newPluginCommand(stdout, stderr))
+	root.AddCommand(newSkillCommand(stdout, stderr))
 	root.AddCommand(newDoctorCommand(stdout, stderr))
 
 	return root

--- a/cmd/cowork-mdm/cli/skill_cmd.go
+++ b/cmd/cowork-mdm/cli/skill_cmd.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krislavten/cowork-mdm/internal/skillpack"
+)
+
+func newSkillCommand(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Package skills for MDM delivery via org-plugins/",
+		Long: "Cowork's org-plugins/ mount folder only loads plugin bundles.\n" +
+			"`skill pack` wraps a directory of skills in a minimal plugin bundle\n" +
+			"so a company skill library can be delivered through the same MDM\n" +
+			"channel used for regular plugins.",
+	}
+	cmd.AddCommand(newSkillPackCommand(stdout, stderr))
+	return cmd
+}
+
+func newSkillPackCommand(stdout, _ io.Writer) *cobra.Command {
+	var (
+		name        string
+		out         string
+		version     string
+		description string
+		authorName  string
+		authorEmail string
+		force       bool
+	)
+	c := &cobra.Command{
+		Use:   "pack INPUT_DIR",
+		Short: "Wrap a skills directory in a plugin bundle for org-plugins/",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+			if out == "" {
+				return fmt.Errorf("--out is required")
+			}
+			res, err := skillpack.Pack(args[0], out, skillpack.Options{
+				Name:        name,
+				Version:     version,
+				Description: description,
+				AuthorName:  authorName,
+				AuthorEmail: authorEmail,
+				Force:       force,
+			})
+			if err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				enc := json.NewEncoder(stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(res)
+			}
+			for _, s := range res.Skills {
+				fmt.Fprintf(stdout, "  - %s — %s\n", s.Name, s.Description)
+			}
+			fmt.Fprintf(stdout, "Packed %d skill(s) into %s\n", len(res.Skills), res.BundleDir)
+			return nil
+		},
+	}
+	c.Flags().StringVar(&name, "name", "", "plugin bundle name (required; lowercase-kebab)")
+	c.Flags().StringVar(&out, "out", "", "output bundle directory (required)")
+	c.Flags().StringVar(&version, "version", "0.1.0", "plugin version written into plugin.json")
+	c.Flags().StringVar(&description, "description", "", "plugin description (defaults to a generic placeholder)")
+	c.Flags().StringVar(&authorName, "author", "", "optional author name")
+	c.Flags().StringVar(&authorEmail, "author-email", "", "optional author email (requires --author)")
+	c.Flags().BoolVar(&force, "force", false, "overwrite --out if it already exists")
+	_ = c.MarkFlagRequired("name")
+	_ = c.MarkFlagRequired("out")
+	return c
+}

--- a/internal/skillpack/skillpack.go
+++ b/internal/skillpack/skillpack.go
@@ -1,0 +1,703 @@
+// Package skillpack turns a directory of skills into a Claude Desktop
+// plugin bundle suitable for delivery via org-plugins/.
+//
+// Claude Desktop only loads plugin bundles (directories with
+// .claude-plugin/plugin.json) from org-plugins/. A bare skill directory
+// is silently ignored. skillpack.Pack wraps a skills source tree in the
+// minimal plugin shell so IT admins can ship skill libraries through the
+// same MDM channel used for regular plugins.
+package skillpack
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"syscall"
+)
+
+// Options controls the bundle emitted by Pack. See specs/skillpack.md.
+type Options struct {
+	Name        string
+	Version     string
+	Description string
+	AuthorName  string
+	AuthorEmail string
+	Force       bool
+}
+
+// Result summarizes what Pack produced.
+type Result struct {
+	BundleDir string
+	Skills    []PackedSkill
+}
+
+// PackedSkill describes one skill included in the bundle.
+type PackedSkill struct {
+	Name            string
+	FrontmatterName string
+	Description     string
+}
+
+// Sentinel errors — see spec.
+var (
+	ErrInvalidName    = errors.New("skillpack: invalid bundle name")
+	ErrMissingVersion = errors.New("skillpack: version is required")
+	ErrInputNotFound  = errors.New("skillpack: input directory not found")
+	ErrNoSkills       = errors.New("skillpack: no skills found in input")
+	ErrInvalidSkill   = errors.New("skillpack: invalid skill")
+	ErrOutDirNotEmpty = errors.New("skillpack: output directory not empty")
+	ErrUnsafeOutDir   = errors.New("skillpack: unsafe output directory")
+)
+
+var bundleNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// defaultDescription is used when Options.Description is empty.
+const defaultDescription = "Internal skills packaged by cowork-mdm skill pack"
+
+// Pack reads inputDir, detects the layout, validates every skill, stages
+// the bundle in a sibling temp directory, then atomically renames it into
+// place. Pack never partially overwrites outDir — callers can retry after
+// any error and be confident the previous bundle (if any) is intact or
+// fully replaced.
+func Pack(inputDir, outDir string, opts Options) (*Result, error) {
+	if !bundleNameRE.MatchString(opts.Name) {
+		return nil, fmt.Errorf("%w: %q (must match ^[a-z0-9][a-z0-9-]*$)", ErrInvalidName, opts.Name)
+	}
+	if strings.TrimSpace(opts.Version) == "" {
+		return nil, ErrMissingVersion
+	}
+
+	inputDir = filepath.Clean(inputDir)
+	outDir = filepath.Clean(outDir)
+
+	info, err := os.Stat(inputDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrInputNotFound, inputDir)
+		}
+		return nil, fmt.Errorf("skillpack: stat input: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%w: %s is not a directory", ErrInputNotFound, inputDir)
+	}
+
+	absIn, err := resolveCanonical(inputDir)
+	if err != nil {
+		return nil, fmt.Errorf("skillpack: resolve input: %w", err)
+	}
+	// absOutLiteral: the literal outDir path, made absolute but NOT
+	// symlink-resolved. This is what we Lstat, RemoveAll, and Rename to —
+	// so we never write *through* a symlink that happens to sit at outDir.
+	absOutLiteral, err := filepath.Abs(outDir)
+	if err != nil {
+		return nil, fmt.Errorf("skillpack: resolve output: %w", err)
+	}
+	// absOutResolved: same path with every symlink in the existing prefix
+	// resolved, so the inside-input check catches cases where outDir (or
+	// an ancestor) symlinks back into inputDir.
+	absOutResolved, err := resolveOutCanonical(absOutLiteral)
+	if err != nil {
+		return nil, fmt.Errorf("skillpack: resolve output: %w", err)
+	}
+	if isSameOrInside(absOutResolved, absIn) {
+		return nil, fmt.Errorf("%w: output %s resolves inside input %s", ErrUnsafeOutDir, absOutResolved, absIn)
+	}
+
+	skillsRoot, skills, err := detectSkills(inputDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(skills) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrNoSkills, inputDir)
+	}
+
+	packed := make([]PackedSkill, 0, len(skills))
+	for _, s := range skills {
+		fm, err := parseSkillFrontmatter(filepath.Join(skillsRoot, s, "SKILL.md"))
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s: %v", ErrInvalidSkill, s, err)
+		}
+		packed = append(packed, PackedSkill{
+			Name:            s,
+			FrontmatterName: fm.name,
+			Description:     fm.description,
+		})
+	}
+	sort.Slice(packed, func(i, j int) bool { return packed[i].Name < packed[j].Name })
+
+	// Make sure outDir's parent exists and the existing state is acceptable
+	// BEFORE staging, so we fail fast without building a temp bundle we'd
+	// have to delete. Policy runs against the literal path — we refuse to
+	// treat a symlink at outDir as "our directory to overwrite." The
+	// policy value is carried forward to commitBundle so a racer who
+	// creates content at outDir mid-Pack cannot hijack commit branch
+	// selection.
+	policy, err := checkOutDirPolicy(absOutLiteral, opts.Force)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stage the new bundle into a sibling temp dir of the literal outDir.
+	// os.Rename between two entries in the same directory is atomic on the
+	// same filesystem.
+	parent := filepath.Dir(absOutLiteral)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return nil, fmt.Errorf("skillpack: create output parent: %w", err)
+	}
+	staged, err := os.MkdirTemp(parent, ".skillpack-stage-")
+	if err != nil {
+		return nil, fmt.Errorf("skillpack: mkdir stage: %w", err)
+	}
+	// If anything below fails, scrub the staged tree so we never leave
+	// half-written state behind.
+	cleanupStaged := func() { _ = os.RemoveAll(staged) }
+
+	if err := os.MkdirAll(filepath.Join(staged, ".claude-plugin"), 0o755); err != nil {
+		cleanupStaged()
+		return nil, fmt.Errorf("skillpack: create bundle dir: %w", err)
+	}
+	if err := writeManifest(filepath.Join(staged, ".claude-plugin", "plugin.json"), opts); err != nil {
+		cleanupStaged()
+		return nil, err
+	}
+	if err := writeReadme(filepath.Join(staged, "README.md"), opts, packed); err != nil {
+		cleanupStaged()
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Join(staged, "skills"), 0o755); err != nil {
+		cleanupStaged()
+		return nil, fmt.Errorf("skillpack: create skills dir: %w", err)
+	}
+	for _, s := range packed {
+		src := filepath.Join(skillsRoot, s.Name)
+		dst := filepath.Join(staged, "skills", s.Name)
+		if err := copySkillTree(src, dst); err != nil {
+			cleanupStaged()
+			return nil, fmt.Errorf("skillpack: copy %s: %w", s.Name, err)
+		}
+	}
+
+	// Commit. The branch is decided by the policy captured at
+	// validation time, not by a fresh Lstat at commit time, so a racer
+	// that creates content at outDir mid-Pack cannot trick us into
+	// treating their content as an existing bundle to sweep aside.
+	if err := commitBundle(staged, absOutLiteral, policy); err != nil {
+		cleanupStaged()
+		return nil, err
+	}
+
+	return &Result{BundleDir: absOutLiteral, Skills: packed}, nil
+}
+
+// commitBundle moves the staged bundle into place atomically. The
+// branch is driven by the policy captured at validation time, not by
+// a fresh Lstat — that way a racer who creates content at dest while
+// we stage cannot coerce us into a destructive path. None of the
+// branches issue RemoveAll against dest.
+//
+//   - outDirAbsent: plain os.Rename. If a racer creates any content
+//     at dest between validation and commit, Rename fails (EEXIST on
+//     macOS, ENOTEMPTY on Linux) and Pack aborts; racer content
+//     preserved.
+//   - outDirEmpty: syscall.Rmdir(dest) followed by os.Rename. Rmdir
+//     is directory-only on every supported platform: it fails with
+//     ENOTDIR if dest was swapped for a regular file, and ENOTEMPTY
+//     if dest was populated. os.Remove would happily delete a regular
+//     file, which is why Rmdir is used here.
+//   - outDirForceReplace: move existing dest to sidecar via os.Rename
+//     (atomic), install staged at dest, then RemoveAll the sidecar.
+//     Sidecar is at a path we constructed so RemoveAll only wipes
+//     state we own.
+func commitBundle(staged, dest string, policy outDirPolicy) error {
+	switch policy {
+	case outDirAbsent:
+		if err := os.Rename(staged, dest); err != nil {
+			return fmt.Errorf("skillpack: install bundle: %w", err)
+		}
+		return nil
+	case outDirEmpty:
+		// syscall.Rmdir is directory-only on all supported platforms:
+		// fails with ENOTDIR if the path is now a regular file, and
+		// ENOTEMPTY if the path is now a populated dir. Either way,
+		// a racer that swapped dest between validation and commit
+		// causes this to fail and Pack aborts. os.Remove would happily
+		// delete a regular file, which is the hole Codex flagged.
+		if err := syscall.Rmdir(dest); err != nil {
+			return fmt.Errorf("skillpack: install bundle: %s changed during commit: %w",
+				dest, err)
+		}
+		if err := os.Rename(staged, dest); err != nil {
+			return fmt.Errorf("skillpack: install bundle: %w", err)
+		}
+		return nil
+	case outDirForceReplace:
+		parent := filepath.Dir(dest)
+		base := filepath.Base(dest)
+		sidecar, err := uniquePath(parent, ".skillpack-old-"+base+"-")
+		if err != nil {
+			return fmt.Errorf("skillpack: pick sidecar: %w", err)
+		}
+		if err := os.Rename(dest, sidecar); err != nil {
+			return fmt.Errorf("skillpack: move existing bundle aside: %w", err)
+		}
+		if err := os.Rename(staged, dest); err != nil {
+			if rbErr := os.Rename(sidecar, dest); rbErr != nil {
+				return fmt.Errorf("skillpack: install bundle: %w; rollback also failed: %v", err, rbErr)
+			}
+			return fmt.Errorf("skillpack: install bundle: %w", err)
+		}
+		if err := os.RemoveAll(sidecar); err != nil {
+			return fmt.Errorf("skillpack: bundle installed but failed to remove old copy at %s: %w", sidecar, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("skillpack: internal: unknown outDirPolicy %d", policy)
+	}
+}
+
+// uniquePath returns a path in dir with the given prefix that is
+// guaranteed not to collide with an existing entry. Uses MkdirTemp's
+// atomicity guarantee, then removes the empty dir it created so the
+// caller can use the path as a rename target.
+func uniquePath(dir, prefix string) (string, error) {
+	tmp, err := os.MkdirTemp(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	// Remove the placeholder so os.Rename can target the path.
+	if err := os.Remove(tmp); err != nil {
+		return "", err
+	}
+	return tmp, nil
+}
+
+// detectSkills resolves the skills root and returns the ordered list of
+// skill directory names. See spec for layout rules.
+func detectSkills(inputDir string) (root string, skills []string, err error) {
+	rootSkills, err := listSkillDirs(inputDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("skillpack: read input: %w", err)
+	}
+	if len(rootSkills) > 0 {
+		return inputDir, rootSkills, nil
+	}
+	nested := filepath.Join(inputDir, "skills")
+	if info, serr := os.Stat(nested); serr == nil && info.IsDir() {
+		nestedSkills, err := listSkillDirs(nested)
+		if err != nil {
+			return "", nil, fmt.Errorf("skillpack: read skills/: %w", err)
+		}
+		if len(nestedSkills) > 0 {
+			return nested, nestedSkills, nil
+		}
+	}
+	return inputDir, nil, nil
+}
+
+// listSkillDirs returns subdirectory names of dir that contain a SKILL.md.
+// Follows symlinks at the top level so a linked skill dir still works,
+// but leaves deeper traversal to copySkillTree.
+func listSkillDirs(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		if e.Name() == "skills" {
+			// Never treat the nested skills/ dir itself as a skill.
+			continue
+		}
+		// os.Stat follows symlinks so a symlinked skill directory is
+		// accepted at the top level.
+		info, err := os.Stat(filepath.Join(dir, e.Name()))
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(dir, e.Name(), "SKILL.md")
+		if info, err := os.Stat(skillFile); err == nil && !info.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+type skillFrontmatter struct {
+	name        string
+	description string
+}
+
+var frontmatterRE = regexp.MustCompile(`(?s)\A---\s*\n(.*?)\n---\s*\n`)
+
+// parseSkillFrontmatter loads SKILL.md and extracts name + description.
+// Only supports a tiny YAML subset (key: value on single lines). That's
+// what Claude Desktop's own parser handles, so matching scope is correct.
+func parseSkillFrontmatter(path string) (skillFrontmatter, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return skillFrontmatter{}, err
+	}
+	m := frontmatterRE.FindSubmatch(data)
+	if m == nil {
+		return skillFrontmatter{}, fmt.Errorf("SKILL.md missing YAML frontmatter")
+	}
+	fm := skillFrontmatter{}
+	for _, line := range strings.Split(string(m[1]), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		switch key {
+		case "name":
+			fm.name = value
+		case "description":
+			fm.description = value
+		}
+	}
+	if fm.name == "" {
+		return fm, fmt.Errorf("SKILL.md frontmatter missing 'name'")
+	}
+	if fm.description == "" {
+		return fm, fmt.Errorf("SKILL.md frontmatter missing 'description'")
+	}
+	return fm, nil
+}
+
+// resolveCanonical returns an absolute path with all symlinks resolved.
+// Used for the input directory, which must already exist.
+func resolveCanonical(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// resolveOutCanonical resolves as much of an absolute path as currently
+// exists, then appends the still-missing tail. This catches an outDir
+// whose eventual physical location would land inside inputDir, even when
+// the outDir itself doesn't exist yet.
+//
+// A broken symlink along the path is treated as if the entry didn't
+// exist — we walk past it and continue upward until EvalSymlinks
+// succeeds, or we hit the filesystem root. This matches the "best
+// effort, never fail the caller" contract the Pack guard needs.
+func resolveOutCanonical(abs string) (string, error) {
+	prefix := abs
+	var tail []string
+	for {
+		// Walk up until we find an entry we can resolve. An entry that
+		// exists (Lstat) but whose EvalSymlinks fails (broken symlink,
+		// permission denied on the target) is treated as "not usable for
+		// canonicalisation" — we append it to the tail and try the parent.
+		if info, err := os.Lstat(prefix); err == nil {
+			if info.Mode()&os.ModeSymlink == 0 {
+				// Real file/dir — EvalSymlinks will succeed.
+				break
+			}
+			// It's a symlink. Try to resolve; if it works, break.
+			if _, err := filepath.EvalSymlinks(prefix); err == nil {
+				break
+			}
+			// Broken symlink — treat as not present and fall through.
+		}
+		parent := filepath.Dir(prefix)
+		if parent == prefix {
+			// Hit filesystem root without finding a resolvable ancestor.
+			return abs, nil
+		}
+		tail = append([]string{filepath.Base(prefix)}, tail...)
+		prefix = parent
+	}
+	resolved, err := filepath.EvalSymlinks(prefix)
+	if err != nil {
+		return "", err
+	}
+	if len(tail) == 0 {
+		return resolved, nil
+	}
+	return filepath.Join(append([]string{resolved}, tail...)...), nil
+}
+
+// isSameOrInside reports whether a is equal to b or lives under b.
+// Both arguments must already be absolute and symlink-resolved.
+func isSameOrInside(a, b string) bool {
+	if a == b {
+		return true
+	}
+	sep := string(filepath.Separator)
+	return strings.HasPrefix(a+sep, b+sep)
+}
+
+// checkOutDirPolicy verifies outDir is either absent, empty-ish, or
+// force is set. It never mutates the filesystem.
+//
+// Returns (policy, err). policy describes how commitBundle should
+// handle the destination — see outDirPolicy docs. Threading this bit
+// through the Pack body keeps a racer from hijacking commit behaviour
+// after the initial check.
+type outDirPolicy int
+
+const (
+	// outDirAbsent: dest did not exist at validation time. Commit uses
+	// a plain os.Rename. If a racer creates any content at dest between
+	// validation and commit, Rename fails (EEXIST on macOS, ENOTEMPTY
+	// on Linux) and Pack aborts — racer content is preserved.
+	outDirAbsent outDirPolicy = iota
+	// outDirEmpty: dest existed as a truly empty directory (no visible
+	// entries and no hidden entries). Commit does syscall.Rmdir(dest)
+	// followed by os.Rename. Rmdir is directory-only: if a racer
+	// swapped dest for a regular file or populated the dir, Rmdir
+	// fails and Pack aborts without deleting their content.
+	outDirEmpty
+	// outDirForceReplace: dest existed with content and --force was
+	// supplied (or is a symlink / non-directory file with --force, or
+	// a dotfile-only dir with --force). Commit uses the sidecar path:
+	// move existing aside, install staged, RemoveAll the sidecar.
+	// RemoveAll targets a path Pack picks, not the user-facing dest.
+	outDirForceReplace
+)
+
+func checkOutDirPolicy(outDir string, force bool) (outDirPolicy, error) {
+	info, err := os.Lstat(outDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return outDirAbsent, nil
+		}
+		return 0, fmt.Errorf("skillpack: inspect output: %w", err)
+	}
+	// Refuse to treat a symlink at outDir as "our own directory to
+	// overwrite" — we won't write through it. Force required to
+	// explicitly replace.
+	if info.Mode()&os.ModeSymlink != 0 {
+		if !force {
+			return 0, fmt.Errorf("%w: %s is a symlink (re-run with --force to replace)",
+				ErrUnsafeOutDir, outDir)
+		}
+		return outDirForceReplace, nil
+	}
+	if !info.IsDir() {
+		if !force {
+			return 0, fmt.Errorf("%w: %s exists and is not a directory (re-run with --force to replace)",
+				ErrUnsafeOutDir, outDir)
+		}
+		return outDirForceReplace, nil
+	}
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		return 0, fmt.Errorf("skillpack: inspect output: %w", err)
+	}
+	nonHidden := 0
+	hidden := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			hidden++
+		} else {
+			nonHidden++
+		}
+	}
+	if nonHidden > 0 {
+		if !force {
+			return 0, fmt.Errorf("%w: %s", ErrOutDirNotEmpty, outDir)
+		}
+		return outDirForceReplace, nil
+	}
+	// Visible content absent. If hidden entries are present (e.g. a
+	// stray .DS_Store), require --force: without it the sidecar path
+	// would destroy a racer's visible content that appears between
+	// validation and commit, and the plain-rename path can't overwrite
+	// the non-empty dir on macOS. --force is the user's explicit
+	// acknowledgement that this dir is theirs to replace.
+	if hidden > 0 {
+		if !force {
+			return 0, fmt.Errorf("%w: %s (contains hidden entries; re-run with --force to replace)",
+				ErrOutDirNotEmpty, outDir)
+		}
+		return outDirForceReplace, nil
+	}
+	return outDirEmpty, nil
+}
+
+// writeManifest emits plugin.json with stable key order and two-space
+// indentation. We hand-render instead of using encoding/json to keep the
+// output byte-identical across Go minor versions and to control key
+// ordering.
+func writeManifest(path string, opts Options) error {
+	desc := opts.Description
+	if desc == "" {
+		desc = defaultDescription
+	}
+	var b bytes.Buffer
+	b.WriteString("{\n")
+	fmt.Fprintf(&b, "  %s: %s,\n", jsonKey("name"), jsonString(opts.Name))
+	fmt.Fprintf(&b, "  %s: %s,\n", jsonKey("version"), jsonString(opts.Version))
+	if opts.AuthorName != "" {
+		fmt.Fprintf(&b, "  %s: %s,\n", jsonKey("description"), jsonString(desc))
+		b.WriteString("  \"author\": {\n")
+		fmt.Fprintf(&b, "    %s: %s", jsonKey("name"), jsonString(opts.AuthorName))
+		if opts.AuthorEmail != "" {
+			b.WriteString(",\n")
+			fmt.Fprintf(&b, "    %s: %s\n", jsonKey("email"), jsonString(opts.AuthorEmail))
+		} else {
+			b.WriteString("\n")
+		}
+		b.WriteString("  }\n")
+	} else {
+		fmt.Fprintf(&b, "  %s: %s\n", jsonKey("description"), jsonString(desc))
+	}
+	b.WriteString("}\n")
+	return os.WriteFile(path, b.Bytes(), 0o644)
+}
+
+func jsonKey(k string) string { return `"` + k + `"` }
+
+// jsonString escapes per RFC 8259 for the subset of code points that can
+// appear in plugin.json fields: Unicode scalars get written as UTF-8,
+// control chars and the two mandatory escapes (" and \) are escaped.
+// Non-BMP runes (>= 0x10000) are emitted directly as UTF-8 rather than
+// surrogate pairs — JSON parsers accept both; UTF-8 keeps the output
+// readable.
+func jsonString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch {
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '"':
+			b.WriteString(`\"`)
+		case r == '\b':
+			b.WriteString(`\b`)
+		case r == '\f':
+			b.WriteString(`\f`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteString(`\t`)
+		case r < 0x20:
+			fmt.Fprintf(&b, `\u%04x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func writeReadme(path string, opts Options, skills []PackedSkill) error {
+	desc := opts.Description
+	if desc == "" {
+		desc = defaultDescription
+	}
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "# %s\n\n", opts.Name)
+	fmt.Fprintf(&b, "%s\n\n", desc)
+	b.WriteString("Generated by `cowork-mdm skill pack`. Do not edit by hand — regenerate\n")
+	b.WriteString("when the source skills change.\n\n")
+	b.WriteString("## Skills\n\n")
+	for _, s := range skills {
+		fmt.Fprintf(&b, "- **%s** — %s\n", s.Name, s.Description)
+	}
+	return os.WriteFile(path, b.Bytes(), 0o644)
+}
+
+// copySkillTree recursively copies src → dst, resolving symlinks to
+// their targets so the emitted bundle has no external link dependencies.
+// We don't use filepath.WalkDir because it refuses to recurse into
+// symlinked directories, which would silently drop content.
+func copySkillTree(src, dst string) error {
+	return copySkillTreeGuarded(src, dst, nil)
+}
+
+// copySkillTreeGuarded is copySkillTree with an ancestor-chain cycle
+// guard. ancestors is the stack of canonical directory paths currently
+// open on the call stack. A cycle exists only when a descendant points
+// back at one of those ancestors (not when two siblings happen to link
+// to the same external directory — both of those should be copied).
+func copySkillTreeGuarded(src, dst string, ancestors []string) error {
+	info, err := os.Stat(src) // follows symlinks
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		// Canonicalise for cycle detection. If EvalSymlinks fails, fall
+		// back to the lexical path — we'd rather do one extra traversal
+		// than bail with an ambiguous error.
+		canonical := src
+		if resolved, err := filepath.EvalSymlinks(src); err == nil {
+			canonical = resolved
+		}
+		for _, a := range ancestors {
+			if a == canonical {
+				return fmt.Errorf("skillpack: symlink cycle detected at %s", src)
+			}
+		}
+		ancestors = append(ancestors, canonical)
+		if err := os.MkdirAll(dst, 0o755); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := copySkillTreeGuarded(
+				filepath.Join(src, e.Name()),
+				filepath.Join(dst, e.Name()),
+				ancestors,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("skillpack: unsupported file type at %s", src)
+	}
+	return copyFile(src, dst, info.Mode().Perm())
+}
+
+func copyFile(src, dst string, perm fs.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/skillpack/skillpack.go
+++ b/internal/skillpack/skillpack.go
@@ -411,7 +411,7 @@ func resolveOutCanonical(abs string) (string, error) {
 		// Walk up until we find an entry we can resolve. An entry that
 		// exists (Lstat) but whose EvalSymlinks fails (broken symlink,
 		// permission denied on the target) is treated as "not usable for
-		// canonicalisation" — we append it to the tail and try the parent.
+		// canonicalization" — we append it to the tail and try the parent.
 		if info, err := os.Lstat(prefix); err == nil {
 			if info.Mode()&os.ModeSymlink == 0 {
 				// Real file/dir — EvalSymlinks will succeed.
@@ -456,7 +456,7 @@ func isSameOrInside(a, b string) bool {
 //
 // Returns (policy, err). policy describes how commitBundle should
 // handle the destination — see outDirPolicy docs. Threading this bit
-// through the Pack body keeps a racer from hijacking commit behaviour
+// through the Pack body keeps a racer from hijacking commit behavior
 // after the initial check.
 type outDirPolicy int
 

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -505,7 +505,7 @@ func TestPack_AtomicOnSkillCopyFailure(t *testing.T) {
 // TestPack_ForceHandlesBrokenSymlinkOutDir covers the round-2 MUST-FIX:
 // a dangling symlink at outDir used to make resolveOutCanonical fail
 // before the Force-aware policy could run. Now a broken symlink is
-// treated as non-canonicalisable, and Force replaces it.
+// treated as non-canonicalizable, and Force replaces it.
 func TestPack_ForceHandlesBrokenSymlinkOutDir(t *testing.T) {
 	in := t.TempDir()
 	writeSkill(t, in, "s", "s", "s", nil)
@@ -533,7 +533,7 @@ func TestPack_ForceHandlesBrokenSymlinkOutDir(t *testing.T) {
 
 // TestPack_RefusesBrokenSymlinkOutDirWithoutForce: the mirror case. A
 // broken symlink at outDir without --force must error via policy, not
-// via a canonicalisation failure.
+// via a canonicalization failure.
 func TestPack_RefusesBrokenSymlinkOutDirWithoutForce(t *testing.T) {
 	in := t.TempDir()
 	writeSkill(t, in, "s", "s", "s", nil)

--- a/internal/skillpack/skillpack_test.go
+++ b/internal/skillpack/skillpack_test.go
@@ -1,0 +1,880 @@
+package skillpack
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkill creates a skill directory at dir/name with the given frontmatter
+// plus an optional extra file. Returns the skill directory path.
+func writeSkill(t *testing.T, dir, name, fmName, fmDesc string, extras map[string]string) string {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var body strings.Builder
+	body.WriteString("---\n")
+	if fmName != "" {
+		body.WriteString("name: " + fmName + "\n")
+	}
+	if fmDesc != "" {
+		body.WriteString("description: " + fmDesc + "\n")
+	}
+	body.WriteString("---\n\nBody.\n")
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for path, content := range extras {
+		full := filepath.Join(skillDir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return skillDir
+}
+
+func defaultOpts() Options {
+	return Options{
+		Name:        "test-skills",
+		Version:     "0.1.0",
+		Description: "unit test bundle",
+	}
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("plugin.json is not valid JSON: %v\n%s", err, data)
+	}
+	return out
+}
+
+func TestPack_LayoutA(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "alpha", "alpha", "Alpha desc", nil)
+	writeSkill(t, in, "bravo", "bravo", "Bravo desc", map[string]string{
+		"references/note.md": "supporting material\n",
+	})
+
+	out := filepath.Join(t.TempDir(), "bundle")
+	res, err := Pack(in, out, defaultOpts())
+	if err != nil {
+		t.Fatalf("Pack failed: %v", err)
+	}
+	if got, want := len(res.Skills), 2; got != want {
+		t.Errorf("res.Skills count = %d, want %d", got, want)
+	}
+	if res.Skills[0].Name != "alpha" || res.Skills[1].Name != "bravo" {
+		t.Errorf("skills not sorted: %+v", res.Skills)
+	}
+	// plugin.json
+	m := readJSON(t, filepath.Join(out, ".claude-plugin", "plugin.json"))
+	if m["name"] != "test-skills" {
+		t.Errorf("plugin.json name = %v", m["name"])
+	}
+	if m["version"] != "0.1.0" {
+		t.Errorf("plugin.json version = %v", m["version"])
+	}
+	if m["description"] != "unit test bundle" {
+		t.Errorf("plugin.json description = %v", m["description"])
+	}
+	if _, ok := m["author"]; ok {
+		t.Errorf("plugin.json should have no author block when AuthorName empty")
+	}
+	// README
+	readme, err := os.ReadFile(filepath.Join(out, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"# test-skills", "alpha", "bravo", "Alpha desc", "Bravo desc"} {
+		if !strings.Contains(string(readme), want) {
+			t.Errorf("README missing %q", want)
+		}
+	}
+	// skills/ tree copied, including extras
+	if _, err := os.Stat(filepath.Join(out, "skills", "bravo", "references", "note.md")); err != nil {
+		t.Errorf("bravo reference file not copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "skills", "alpha", "SKILL.md")); err != nil {
+		t.Errorf("alpha SKILL.md not copied: %v", err)
+	}
+}
+
+func TestPack_LayoutB(t *testing.T) {
+	in := t.TempDir()
+	skillsRoot := filepath.Join(in, "skills")
+	if err := os.MkdirAll(skillsRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSkill(t, skillsRoot, "nested", "nested", "Nested desc", nil)
+
+	out := filepath.Join(t.TempDir(), "bundle")
+	res, err := Pack(in, out, defaultOpts())
+	if err != nil {
+		t.Fatalf("Pack failed: %v", err)
+	}
+	if len(res.Skills) != 1 || res.Skills[0].Name != "nested" {
+		t.Errorf("expected [nested], got %+v", res.Skills)
+	}
+	if _, err := os.Stat(filepath.Join(out, "skills", "nested", "SKILL.md")); err != nil {
+		t.Errorf("nested skill not copied: %v", err)
+	}
+}
+
+func TestPack_IgnoresStraySkillsDirInLayoutA(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "root-skill", "root-skill", "desc", nil)
+	// A stray skills/ sibling — must be ignored because Layout A already matched.
+	if err := os.MkdirAll(filepath.Join(in, "skills", "hidden-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(in, "skills", "hidden-skill", "SKILL.md"),
+		[]byte("---\nname: hidden\ndescription: x\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "bundle")
+	res, err := Pack(in, out, defaultOpts())
+	if err != nil {
+		t.Fatalf("Pack failed: %v", err)
+	}
+	if len(res.Skills) != 1 || res.Skills[0].Name != "root-skill" {
+		t.Errorf("expected [root-skill] only; Layout A should win. got %+v", res.Skills)
+	}
+}
+
+func TestPack_RejectsInvalidName(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "any", "any", "any", nil)
+	for _, bad := range []string{"", "Foo", "-foo", "foo/bar", "foo_bar", "FOO"} {
+		opts := defaultOpts()
+		opts.Name = bad
+		out := filepath.Join(t.TempDir(), "bundle")
+		_, err := Pack(in, out, opts)
+		if !errors.Is(err, ErrInvalidName) {
+			t.Errorf("name %q: want ErrInvalidName, got %v", bad, err)
+		}
+	}
+}
+
+func TestPack_RejectsMissingVersion(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "any", "any", "any", nil)
+	opts := defaultOpts()
+	opts.Version = ""
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, opts); !errors.Is(err, ErrMissingVersion) {
+		t.Errorf("empty version: want ErrMissingVersion, got %v", err)
+	}
+}
+
+func TestPack_RejectsMissingFrontmatter(t *testing.T) {
+	in := t.TempDir()
+	skillDir := filepath.Join(in, "bad")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("no frontmatter here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "bundle")
+	_, err := Pack(in, out, defaultOpts())
+	if !errors.Is(err, ErrInvalidSkill) {
+		t.Errorf("missing frontmatter: want ErrInvalidSkill, got %v", err)
+	}
+}
+
+func TestPack_RejectsMissingRequiredFields(t *testing.T) {
+	cases := []struct {
+		label  string
+		fmName string
+		fmDesc string
+	}{
+		{"no-name", "", "desc"},
+		{"no-desc", "name", ""},
+		{"neither", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			in := t.TempDir()
+			writeSkill(t, in, "s", c.fmName, c.fmDesc, nil)
+			out := filepath.Join(t.TempDir(), "bundle")
+			_, err := Pack(in, out, defaultOpts())
+			if !errors.Is(err, ErrInvalidSkill) {
+				t.Errorf("want ErrInvalidSkill, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPack_RejectsNoSkills(t *testing.T) {
+	in := t.TempDir()
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, defaultOpts()); !errors.Is(err, ErrNoSkills) {
+		t.Errorf("empty input: want ErrNoSkills, got %v", err)
+	}
+}
+
+func TestPack_RejectsMissingInput(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "bundle")
+	_, err := Pack(filepath.Join(t.TempDir(), "nope"), out, defaultOpts())
+	if !errors.Is(err, ErrInputNotFound) {
+		t.Errorf("missing input: want ErrInputNotFound, got %v", err)
+	}
+}
+
+func TestPack_RejectsNonEmptyOutDirWithoutForce(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	out := filepath.Join(t.TempDir(), "bundle")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(out, "pre-existing.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Pack(in, out, defaultOpts())
+	if !errors.Is(err, ErrOutDirNotEmpty) {
+		t.Errorf("want ErrOutDirNotEmpty, got %v", err)
+	}
+	// With Force: should succeed and replace contents.
+	opts := defaultOpts()
+	opts.Force = true
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Fatalf("Force Pack failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "pre-existing.txt")); err == nil {
+		t.Errorf("pre-existing.txt should have been removed under Force")
+	}
+}
+
+// TestPack_AcceptsEmptyExistingOutDir verifies that an outDir directory
+// that exists but is empty is treated like absent: Pack succeeds without
+// --force and the bundle lands correctly.
+func TestPack_AcceptsEmptyExistingOutDir(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	out := filepath.Join(t.TempDir(), "bundle")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Pack(in, out, defaultOpts()); err != nil {
+		t.Fatalf("empty existing outDir should be accepted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, ".claude-plugin", "plugin.json")); err != nil {
+		t.Errorf("plugin.json missing after commit: %v", err)
+	}
+}
+
+// TestPack_HiddenFilesInOutDirRequireForce documents the tightened
+// safety policy: even a dotfile-only outDir requires --force because
+// committing otherwise would expose a TOCTOU race where a concurrent
+// write of a visible file between validation and commit could be
+// destroyed by sidecar cleanup.
+func TestPack_HiddenFilesInOutDirRequireForce(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	out := filepath.Join(t.TempDir(), "bundle")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(out, ".DS_Store"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Pack(in, out, defaultOpts()); !errors.Is(err, ErrOutDirNotEmpty) {
+		t.Errorf("hidden-only outDir: want ErrOutDirNotEmpty, got %v", err)
+	}
+	opts := defaultOpts()
+	opts.Force = true
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Errorf("hidden-only outDir with --force should succeed: %v", err)
+	}
+}
+
+func TestPack_ReproducibleBytes(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "z", "z", "Z desc", nil)
+	writeSkill(t, in, "a", "a", "A desc", nil)
+
+	outA := filepath.Join(t.TempDir(), "a")
+	outB := filepath.Join(t.TempDir(), "b")
+	if _, err := Pack(in, outA, defaultOpts()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Pack(in, outB, defaultOpts()); err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{".claude-plugin/plugin.json", "README.md"} {
+		aBytes, _ := os.ReadFile(filepath.Join(outA, rel))
+		bBytes, _ := os.ReadFile(filepath.Join(outB, rel))
+		if string(aBytes) != string(bBytes) {
+			t.Errorf("%s not reproducible:\n--- A ---\n%s\n--- B ---\n%s", rel, aBytes, bBytes)
+		}
+	}
+}
+
+func TestPack_AuthorBlock(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	opts := defaultOpts()
+	opts.AuthorName = "Your Org"
+	opts.AuthorEmail = "it@example.com"
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Fatal(err)
+	}
+	m := readJSON(t, filepath.Join(out, ".claude-plugin", "plugin.json"))
+	author, ok := m["author"].(map[string]any)
+	if !ok {
+		t.Fatalf("plugin.json author block missing or wrong type: %v", m["author"])
+	}
+	if author["name"] != "Your Org" || author["email"] != "it@example.com" {
+		t.Errorf("author block = %+v", author)
+	}
+}
+
+func TestPack_AuthorEmailOmittedWhenBlank(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	opts := defaultOpts()
+	opts.AuthorName = "Your Org"
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Fatal(err)
+	}
+	m := readJSON(t, filepath.Join(out, ".claude-plugin", "plugin.json"))
+	author := m["author"].(map[string]any)
+	if _, has := author["email"]; has {
+		t.Errorf("email key should be absent when empty; got author=%+v", author)
+	}
+}
+
+func TestPack_DefaultDescription(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	opts := defaultOpts()
+	opts.Description = ""
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Fatal(err)
+	}
+	m := readJSON(t, filepath.Join(out, ".claude-plugin", "plugin.json"))
+	if !strings.Contains(m["description"].(string), "Internal skills") {
+		t.Errorf("default description missing: %v", m["description"])
+	}
+}
+
+func TestPack_RejectsOutInsideInput(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	out := filepath.Join(in, "nested-bundle")
+	_, err := Pack(in, out, defaultOpts())
+	if !errors.Is(err, ErrUnsafeOutDir) {
+		t.Errorf("lexically nested outDir: want ErrUnsafeOutDir, got %v", err)
+	}
+}
+
+// TestPack_RejectsOutResolvingIntoInputViaSymlink covers the case where
+// the literal outDir path lies elsewhere but resolves via a symlink
+// inside inputDir — this was MUST-FIX #2 from sparring.
+func TestPack_RejectsOutResolvingIntoInputViaSymlink(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	aliasParent := t.TempDir()
+	alias := filepath.Join(aliasParent, "alias")
+	if err := os.Symlink(in, alias); err != nil {
+		t.Fatalf("make alias symlink: %v", err)
+	}
+	// out's parent resolves through the alias back into inputDir.
+	out := filepath.Join(alias, "resolved-bundle")
+	_, err := Pack(in, out, defaultOpts())
+	if !errors.Is(err, ErrUnsafeOutDir) {
+		t.Errorf("symlinked outDir: want ErrUnsafeOutDir, got %v", err)
+	}
+}
+
+// TestPack_RefusesPreexistingSymlinkOutDir covers MUST-FIX #1: a symlink
+// at outDir without --force must be rejected, not written through.
+func TestPack_RefusesPreexistingSymlinkOutDir(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	realTarget := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.MkdirAll(realTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	if err := os.Symlink(realTarget, out); err != nil {
+		t.Fatalf("seed symlink outDir: %v", err)
+	}
+
+	_, err := Pack(in, out, defaultOpts())
+	if !errors.Is(err, ErrUnsafeOutDir) {
+		t.Errorf("symlink outDir without --force: want ErrUnsafeOutDir, got %v", err)
+	}
+	// The external target must remain untouched.
+	entries, _ := os.ReadDir(realTarget)
+	if len(entries) != 0 {
+		t.Errorf("Pack leaked files into the symlink target: %+v", entries)
+	}
+}
+
+// TestPack_ForceReplacesSymlinkOutDir pairs with the previous test —
+// with --force we replace the symlink itself, and never write through it.
+func TestPack_ForceReplacesSymlinkOutDir(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	realTarget := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.MkdirAll(realTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	if err := os.Symlink(realTarget, out); err != nil {
+		t.Fatalf("seed symlink outDir: %v", err)
+	}
+
+	opts := defaultOpts()
+	opts.Force = true
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Fatalf("Pack with Force on symlink outDir: %v", err)
+	}
+
+	info, err := os.Lstat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("after Force, outDir should be a real directory, not a symlink")
+	}
+	entries, _ := os.ReadDir(realTarget)
+	if len(entries) != 0 {
+		t.Errorf("Pack leaked files into the symlink target even with Force: %+v", entries)
+	}
+}
+
+// TestPack_AtomicOnSkillCopyFailure covers MUST-FIX #3: if a skill copy
+// fails mid-way, no bundle files should remain at outDir.
+func TestPack_AtomicOnSkillCopyFailure(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "good", "good", "good", nil)
+	// "bad" skill has a dangling symlink inside, which makes copySkillTree
+	// fail when it tries to stat the target.
+	writeSkill(t, in, "bad", "bad", "bad", nil)
+	if err := os.Symlink(
+		filepath.Join(t.TempDir(), "does-not-exist"),
+		filepath.Join(in, "bad", "broken.md"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	if _, err := Pack(in, out, defaultOpts()); err == nil {
+		t.Fatal("expected Pack to fail on dangling symlink in skill")
+	}
+
+	if _, err := os.Lstat(out); err == nil {
+		t.Errorf("bundle at %s should not exist after failed Pack", out)
+	}
+	// The parent directory should also be clean of stage temp dirs.
+	entries, _ := os.ReadDir(outParent)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".skillpack-stage-") {
+			t.Errorf("staged temp dir leaked into parent: %s", e.Name())
+		}
+	}
+}
+
+// TestPack_ForceHandlesBrokenSymlinkOutDir covers the round-2 MUST-FIX:
+// a dangling symlink at outDir used to make resolveOutCanonical fail
+// before the Force-aware policy could run. Now a broken symlink is
+// treated as non-canonicalisable, and Force replaces it.
+func TestPack_ForceHandlesBrokenSymlinkOutDir(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	// Broken symlink — target does not exist.
+	if err := os.Symlink(filepath.Join(t.TempDir(), "nowhere"), out); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := defaultOpts()
+	opts.Force = true
+	if _, err := Pack(in, out, opts); err != nil {
+		t.Fatalf("Pack with Force on broken-symlink outDir: %v", err)
+	}
+	info, err := os.Lstat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("after Force, outDir should be a real directory, not a symlink")
+	}
+}
+
+// TestPack_RefusesBrokenSymlinkOutDirWithoutForce: the mirror case. A
+// broken symlink at outDir without --force must error via policy, not
+// via a canonicalisation failure.
+func TestPack_RefusesBrokenSymlinkOutDirWithoutForce(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "nowhere"), out); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Pack(in, out, defaultOpts())
+	if !errors.Is(err, ErrUnsafeOutDir) {
+		t.Errorf("broken-symlink outDir without Force: want ErrUnsafeOutDir, got %v", err)
+	}
+}
+
+// TestPack_DetectsSymlinkCycleInSkillTree covers the round-2 SHOULD-FIX:
+// a symlink loop inside a skill must not cause unbounded recursion.
+func TestPack_DetectsSymlinkCycleInSkillTree(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	// Cycle: s/docs -> . (points back at the skill directory itself).
+	if err := os.Symlink(filepath.Join(in, "s"), filepath.Join(in, "s", "docs")); err != nil {
+		t.Fatal(err)
+	}
+
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	_, err := Pack(in, out, defaultOpts())
+	if err == nil {
+		t.Error("Pack should fail on symlink cycle")
+	} else if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should mention cycle: %v", err)
+	}
+	// And no partial bundle should remain.
+	if _, statErr := os.Lstat(out); statErr == nil {
+		t.Errorf("outDir should not exist after cycle failure")
+	}
+}
+
+// TestCommitBundle_AbsentPathAbortsOnRacedContent unit-tests the commit
+// primitive directly, proving the round-5 TOCTOU property: when policy
+// captured outDirAbsent at validation, commitBundle uses plain Rename,
+// which fails if a racer populated dest before the commit — racer
+// content is preserved byte-for-byte.
+func TestCommitBundle_AbsentPathAbortsOnRacedContent(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "bundle")
+
+	// Stage a faux-bundle dir.
+	staged, err := os.MkdirTemp(parent, "stage-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, "marker"), []byte("staged"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Racer: populated dest with content AFTER the "validation" moment
+	// (we simulate by creating it here). Validation would have seen
+	// absent; commit runs with outDirAbsent policy.
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "raced.txt"), []byte("racer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := commitBundle(staged, dest, outDirAbsent); err == nil {
+		t.Fatal("commitBundle should fail when racer populated dest")
+	}
+	// Racer content must still be intact.
+	got, err := os.ReadFile(filepath.Join(dest, "raced.txt"))
+	if err != nil {
+		t.Fatalf("racer content lost: %v", err)
+	}
+	if string(got) != "racer" {
+		t.Errorf("racer content = %q", got)
+	}
+	// And the staged dir should still exist (Pack's caller is
+	// responsible for cleanup; commitBundle doesn't cleanup on failure).
+	if _, err := os.Stat(filepath.Join(staged, "marker")); err != nil {
+		t.Errorf("staged cleanup should be caller's job: %v", err)
+	}
+}
+
+// TestCommitBundle_EmptyPathAbortsOnRacedContent is the same property
+// for the outDirEmpty branch (existing-empty-dir). A racer populates
+// dest between validation and commit; os.Remove refuses to delete a
+// non-empty dir, commitBundle aborts, racer content preserved.
+func TestCommitBundle_EmptyPathAbortsOnRacedContent(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "bundle")
+
+	// Validation's view: dest exists and is empty.
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Racer populates dest after validation.
+	if err := os.WriteFile(filepath.Join(dest, "raced.txt"), []byte("racer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	staged, err := os.MkdirTemp(parent, "stage-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := commitBundle(staged, dest, outDirEmpty); err == nil {
+		t.Fatal("commitBundle(outDirEmpty) should fail when racer populated dest")
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "raced.txt"))
+	if err != nil {
+		t.Fatalf("racer content lost: %v", err)
+	}
+	if string(got) != "racer" {
+		t.Errorf("racer content = %q", got)
+	}
+}
+
+// TestCommitBundle_EmptyPathAbortsWhenDirReplacedByFile covers the
+// round-6 MUST-FIX: a racer replaces the empty dir with a regular
+// file between validation and commit. os.Remove would happily delete
+// the file; syscall.Rmdir refuses (ENOTDIR), so Pack aborts and the
+// racer's file survives.
+func TestCommitBundle_EmptyPathAbortsWhenDirReplacedByFile(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "bundle")
+
+	// Validation's view: dest existed as empty dir. Now racer
+	// atomically replaces with a regular file.
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(dest); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("racer-file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	staged, err := os.MkdirTemp(parent, "stage-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := commitBundle(staged, dest, outDirEmpty); err == nil {
+		t.Fatal("commitBundle(outDirEmpty) must abort when dest was replaced by a file")
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("racer file lost: %v", err)
+	}
+	if string(got) != "racer-file" {
+		t.Errorf("racer file = %q", got)
+	}
+}
+
+// TestPack_RejectsPopulatedOutDirWithoutForce covers the initial
+// validation layer: if outDir is already populated (visible files)
+// without --force, Pack rejects via ErrOutDirNotEmpty and the
+// content survives unchanged.
+func TestPack_RejectsPopulatedOutDirWithoutForce(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+	outParent := t.TempDir()
+	out := filepath.Join(outParent, "bundle")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(out, "raced.txt"), []byte("racer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Pack(in, out, defaultOpts()); !errors.Is(err, ErrOutDirNotEmpty) {
+		t.Errorf("populated outDir: want ErrOutDirNotEmpty, got %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(out, "raced.txt"))
+	if string(got) != "racer" {
+		t.Errorf("racer content = %q", got)
+	}
+}
+
+// TestPack_AllowsSiblingSymlinksToSameTarget ensures the cycle guard
+// doesn't false-positive on two symlinks pointing at the same external
+// directory (an ancestor-chain, not a global-visited, design).
+func TestPack_AllowsSiblingSymlinksToSameTarget(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	shared := filepath.Join(t.TempDir(), "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shared, "x.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(shared, filepath.Join(in, "s", "docs-a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(shared, filepath.Join(in, "s", "docs-b")); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, defaultOpts()); err != nil {
+		t.Fatalf("Pack should accept sibling symlinks to the same target: %v", err)
+	}
+	// Both copies should be present and populated.
+	for _, name := range []string{"docs-a", "docs-b"} {
+		got, err := os.ReadFile(filepath.Join(out, "skills", "s", name, "x.md"))
+		if err != nil {
+			t.Errorf("skills/s/%s/x.md missing: %v", name, err)
+		} else if string(got) != "hi" {
+			t.Errorf("skills/s/%s/x.md = %q", name, got)
+		}
+	}
+}
+
+// TestPack_CopiesSymlinkedDirectoryContent covers MUST-FIX #4: symlinked
+// subdirectories inside a skill must have their full contents copied,
+// not be silently flattened to empty directories.
+func TestPack_CopiesSymlinkedDirectoryContent(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	external := filepath.Join(t.TempDir(), "ext-docs")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "a.md"), []byte("A"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(external, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "nested", "b.md"), []byte("B"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(in, "s", "docs")); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, defaultOpts()); err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	// Both files, at the right depths.
+	if got, err := os.ReadFile(filepath.Join(out, "skills", "s", "docs", "a.md")); err != nil {
+		t.Errorf("docs/a.md missing: %v", err)
+	} else if string(got) != "A" {
+		t.Errorf("docs/a.md content = %q", got)
+	}
+	if got, err := os.ReadFile(filepath.Join(out, "skills", "s", "docs", "nested", "b.md")); err != nil {
+		t.Errorf("docs/nested/b.md missing: %v", err)
+	} else if string(got) != "B" {
+		t.Errorf("docs/nested/b.md content = %q", got)
+	}
+	// And none of it should be symlinks.
+	info, err := os.Lstat(filepath.Join(out, "skills", "s", "docs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("bundle docs/ should be a real directory, not a symlink")
+	}
+}
+
+// TestJSONString_EscapeTable covers SHOULD-FIX #2: JSON correctness is a
+// stated review priority, so exercise the escape logic directly.
+func TestJSONString_EscapeTable(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{``, `""`},
+		{`plain`, `"plain"`},
+		{`quote "x"`, `"quote \"x\""`},
+		{`back\slash`, `"back\\slash"`},
+		{"line\nbreak", `"line\nbreak"`},
+		{"cr\rlf", `"cr\rlf"`},
+		{"tab\there", `"tab\there"`},
+		{"bell\x07", `"bell\u0007"`},
+		{"bs\bws", `"bs\bws"`},
+		{"ff\f!", `"ff\f!"`},
+		{"unit\x1fsep", `"unit\u001fsep"`},
+		{"UTF-8 中文 — ok", `"UTF-8 中文 — ok"`},
+		{"emoji 😀", `"emoji 😀"`},
+	}
+	for _, c := range cases {
+		if got := jsonString(c.in); got != c.want {
+			t.Errorf("jsonString(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestPack_ResultBundleDirIsAbsolute covers SHOULD-FIX #1: spec says
+// Result.BundleDir must be absolute.
+func TestPack_ResultBundleDirIsAbsolute(t *testing.T) {
+	in := t.TempDir()
+	writeSkill(t, in, "s", "s", "s", nil)
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	relOut := "bundle"
+	res, err := Pack(in, relOut, defaultOpts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(res.BundleDir) {
+		t.Errorf("Result.BundleDir = %q, want absolute path", res.BundleDir)
+	}
+}
+
+func TestPack_FollowsSymlinkedFiles(t *testing.T) {
+	in := t.TempDir()
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "ref.md"), []byte("external ref"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSkill(t, in, "s", "s", "s", nil)
+	if err := os.Symlink(filepath.Join(external, "ref.md"), filepath.Join(in, "s", "ref.md")); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "bundle")
+	if _, err := Pack(in, out, defaultOpts()); err != nil {
+		t.Fatalf("Pack with symlink failed: %v", err)
+	}
+	info, err := os.Lstat(filepath.Join(out, "skills", "s", "ref.md"))
+	if err != nil {
+		t.Fatalf("ref.md not in bundle: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("bundle should contain a regular file, not a symlink")
+	}
+	data, _ := os.ReadFile(filepath.Join(out, "skills", "s", "ref.md"))
+	if string(data) != "external ref" {
+		t.Errorf("ref.md content = %q", data)
+	}
+}

--- a/specs/skillpack.md
+++ b/specs/skillpack.md
@@ -1,0 +1,306 @@
+# Spec: `internal/skillpack/`
+
+## Intent
+
+Package a local collection of skills into a Claude Desktop plugin bundle,
+so an IT admin can drop the output under `org-plugins/` (via MDM) and have
+Cowork load every skill at launch.
+
+Context: Cowork only mounts **plugin bundles** under `org-plugins/` — the
+scanner reads each subdirectory's `.claude-plugin/plugin.json` and skips
+anything without a manifest. A bare `skills/foo/SKILL.md` in the mount
+folder is silently ignored (verified experimentally against Claude.app
+`1.5354.0`). To deliver skills via MDM, they must be wrapped in a minimal
+plugin bundle. `skill pack` automates that wrapping.
+
+## Public interface
+
+```go
+package skillpack
+
+// Options controls the bundle emitted by Pack.
+type Options struct {
+    // Name is the plugin bundle name (required).
+    // Must match ^[a-z0-9][a-z0-9-]*$ — Anthropic's org plugin naming rule.
+    Name string
+
+    // Version is the bundle version (required; default "0.1.0" set by caller).
+    // Free-form string, written verbatim into plugin.json.
+    Version string
+
+    // Description goes into plugin.json. Optional. If empty, Pack writes a
+    // generic placeholder ("Internal skills packaged by cowork-mdm skill pack").
+    Description string
+
+    // AuthorName and AuthorEmail populate plugin.json's author block.
+    // Both optional. If AuthorName is empty the author block is omitted.
+    AuthorName  string
+    AuthorEmail string
+
+    // Force allows OutDir to already exist. When true, OutDir is wiped and
+    // recreated. When false (default), Pack returns ErrOutDirNotEmpty if
+    // OutDir exists and is not empty.
+    Force bool
+}
+
+// Result summarizes what Pack produced.
+type Result struct {
+    // BundleDir is the absolute path of the generated bundle (equal to
+    // OutDir passed to Pack, cleaned).
+    BundleDir string
+
+    // Skills lists the skills that were packaged, ordered alphabetically
+    // by skill name. Each entry has the parsed name/description from the
+    // SKILL.md frontmatter.
+    Skills []PackedSkill
+}
+
+// PackedSkill describes one skill included in the bundle.
+type PackedSkill struct {
+    // Name is the skill's directory name under skills/ in the output bundle.
+    // Copied verbatim from the input directory name.
+    Name string
+
+    // FrontmatterName is the value of the `name:` field in SKILL.md
+    // frontmatter. May differ from Name (directory) — Pack does not
+    // rewrite SKILL.md.
+    FrontmatterName string
+
+    // Description is the value of the `description:` field in SKILL.md
+    // frontmatter. Empty if absent.
+    Description string
+}
+
+// Pack reads inputDir, detects its layout, validates each skill, and writes
+// a plugin bundle to outDir. Pack is idempotent: given the same input it
+// produces byte-identical output (ordered writes, stable JSON key order).
+//
+// inputDir and outDir are filesystem paths. outDir may be absolute or
+// relative; Pack cleans both before use.
+//
+// Pack returns an error if any validation fails. No bundle is written on
+// error — Pack validates fully before emitting.
+func Pack(inputDir, outDir string, opts Options) (*Result, error)
+
+// Sentinel errors. All wrapped with fmt.Errorf("%w: …") to preserve detail.
+var (
+    // ErrInvalidName is returned when opts.Name does not match the
+    // ^[a-z0-9][a-z0-9-]*$ naming rule.
+    ErrInvalidName = errors.New("skillpack: invalid bundle name")
+
+    // ErrMissingVersion is returned when opts.Version is empty.
+    ErrMissingVersion = errors.New("skillpack: version is required")
+
+    // ErrInputNotFound is returned when inputDir does not exist or is not
+    // a directory.
+    ErrInputNotFound = errors.New("skillpack: input directory not found")
+
+    // ErrNoSkills is returned when the detected input layout contains zero
+    // valid skill subdirectories.
+    ErrNoSkills = errors.New("skillpack: no skills found in input")
+
+    // ErrInvalidSkill is returned when a candidate skill directory is
+    // missing SKILL.md or its frontmatter lacks required fields.
+    ErrInvalidSkill = errors.New("skillpack: invalid skill")
+
+    // ErrOutDirNotEmpty is returned when outDir exists and is non-empty
+    // without Options.Force.
+    ErrOutDirNotEmpty = errors.New("skillpack: output directory not empty")
+
+    // ErrUnsafeOutDir is returned when outDir resolves (through symlinks)
+    // inside inputDir, or is a symlink / non-directory file that Pack
+    // refuses to overwrite without Force.
+    ErrUnsafeOutDir = errors.New("skillpack: unsafe output directory")
+)
+```
+
+## Input layout detection
+
+Two layouts are accepted. Detection is a single rule, applied after
+`inputDir` is confirmed to be a directory:
+
+1. **Layout A — skills at the root.** If `inputDir` directly contains one
+   or more subdirectories with a `SKILL.md` file, treat those subdirs
+   as the skill set. Any `skills/` subdirectory at this level is ignored
+   in Layout A.
+2. **Layout B — skills nested under `skills/`.** If Layout A finds zero
+   skills AND `inputDir/skills/` exists AND contains subdirectories with
+   `SKILL.md`, use those.
+3. If neither produces any skill, return `ErrNoSkills`.
+
+Rationale: Layout A matches how users keep a flat skill library
+(`company-skills/foo/SKILL.md`); Layout B matches when users already have
+a bundle-shaped source tree. Rule 1 wins so a mixed tree (`./foo/SKILL.md`
+plus a stray `./skills/`) is unambiguous.
+
+## Validation
+
+For each skill directory:
+
+- `SKILL.md` must exist and be readable.
+- The file must begin with YAML frontmatter (`---\n…\n---\n`).
+- Frontmatter must contain non-empty `name:` and `description:` fields.
+  Both are required by Claude Desktop; missing either causes the skill
+  to load with placeholder metadata, which is a silent footgun worth
+  rejecting at pack time.
+- The directory name (not the frontmatter name) is the identifier used
+  on disk; Pack does not enforce a match between directory name and
+  frontmatter `name` — the two legitimately differ in existing bundles.
+
+Bundle-level:
+
+- `opts.Name` must match `^[a-z0-9][a-z0-9-]*$`.
+- `opts.Version` must be non-empty.
+
+Output dir:
+
+- If `outDir` exists and contains any entries — including hidden files
+  like `.DS_Store` — Pack returns `ErrOutDirNotEmpty` unless
+  `opts.Force`. A truly empty directory at `outDir` is accepted
+  without `--force`.
+- If `outDir` is a symlink or a non-directory file, Pack returns
+  `ErrUnsafeOutDir` unless `opts.Force`.
+- The canonical path (through symlinks) of `outDir` must not be equal
+  to or inside the canonical path of `inputDir`; otherwise
+  `ErrUnsafeOutDir`.
+- Pack never writes to arbitrary locations outside `outDir` — content
+  is staged in a sibling temp directory and moved into place only
+  after every skill has been copied successfully, so a failed Pack
+  cannot leave a half-built bundle behind.
+- Commit is driven by the `outDirPolicy` captured at validation time
+  (one of `outDirAbsent`, `outDirEmpty`, or `outDirForceReplace`), not
+  by a fresh `Lstat` at commit time. This closes the TOCTOU where a
+  racer creates content at `outDir` between validation and commit:
+    - `outDirAbsent` → plain `os.Rename(staged, outDir)`; Rename fails
+      if a racer created any content at outDir, Pack aborts.
+    - `outDirEmpty` → `syscall.Rmdir(outDir)` (directory-only; fails
+      ENOTDIR if outDir was swapped for a regular file, ENOTEMPTY if
+      populated) followed by `os.Rename(staged, outDir)`.
+    - `outDirForceReplace` → move existing `outDir` to a sidecar name
+      via `os.Rename`, install staged at `outDir`, then `RemoveAll`
+      the sidecar. The sidecar is a path Pack picks, so `RemoveAll`
+      only wipes state Pack owns.
+  None of these branches call `RemoveAll` against the user-facing
+  `outDir` path.
+
+## Output layout
+
+```
+outDir/
+├── .claude-plugin/
+│   └── plugin.json
+├── README.md
+└── skills/
+    ├── <skill-a>/SKILL.md
+    ├── <skill-a>/<anything else copied verbatim>
+    └── <skill-b>/...
+```
+
+### `plugin.json`
+
+Emitted with stable key order for reproducibility:
+
+```json
+{
+  "name": "<opts.Name>",
+  "version": "<opts.Version>",
+  "description": "<opts.Description or default>",
+  "author": {
+    "name": "<opts.AuthorName>",
+    "email": "<opts.AuthorEmail>"
+  }
+}
+```
+
+- `author` block omitted entirely when `AuthorName` is empty.
+- `author.email` omitted when empty (but `name` present).
+- Two-space indentation, trailing newline.
+
+### `README.md`
+
+Auto-generated. Lists every packed skill with its frontmatter description.
+Intent: when an IT admin `ls`s the bundle they can see what's inside
+without reading every SKILL.md. Content:
+
+```markdown
+# <opts.Name>
+
+<opts.Description>
+
+Generated by `cowork-mdm skill pack`. Do not edit by hand — regenerate
+when the source skills change.
+
+## Skills
+
+- **<skill-a>** — <frontmatter description>
+- **<skill-b>** — <frontmatter description>
+```
+
+### `skills/` tree
+
+Each skill directory is copied recursively from the input. File modes
+are preserved (rwx bits); timestamps are not preserved (so repeated
+packs produce identical output). Symlinks inside a skill are resolved
+to their targets and copied as files — Pack never writes a symlink to
+the output, so MDM transport stays portable.
+
+## Non-goals
+
+- No zip/tar output. `org-plugins/` mounts directories, not archives.
+- No git init / push / tag. Pack produces a directory; the caller can
+  commit it, push it, or ship it via MDM however they want.
+- No `commands/` / `agents/` / `hooks/` support. `skill pack` is
+  skill-only by design — users with other plugin components should hand-
+  author the bundle.
+- No SKILL.md content linting beyond frontmatter required fields. Future
+  `cowork-mdm skill lint` may do deeper checks.
+- No Windows-specific path handling beyond what `filepath` gives us.
+  `org-plugins/` is mounted the same way on both platforms.
+
+## Testing
+
+`internal/skillpack/skillpack_test.go`:
+
+- `TestPack_LayoutA` — input has skills at root, verifies bundle
+  structure, plugin.json content, README content, and Result metadata.
+- `TestPack_LayoutB` — input has `skills/` subdir, same assertions.
+- `TestPack_IgnoresStraySkillsInLayoutA` — mixed tree picks Layout A.
+- `TestPack_RejectsInvalidName` — names like `Foo`, `-foo`, `foo/bar`,
+  empty → ErrInvalidName.
+- `TestPack_RejectsMissingFrontmatter` — SKILL.md without frontmatter →
+  ErrInvalidSkill.
+- `TestPack_RejectsMissingRequiredFields` — frontmatter without `name`
+  or `description` → ErrInvalidSkill.
+- `TestPack_RejectsNoSkills` — empty input or input with no SKILL.md
+  anywhere → ErrNoSkills.
+- `TestPack_RejectsNonEmptyOutDir` — populated outDir without Force →
+  ErrOutDirNotEmpty; with Force → overwrites.
+- `TestPack_ReproducibleBytes` — packing the same input twice to
+  different outDirs produces byte-identical `plugin.json` and
+  `README.md`.
+- `TestPack_OmitsAuthorWhenEmpty` — no AuthorName → no `author` key in
+  plugin.json.
+
+Fixtures use `t.TempDir()`. No golden files — assertions check specific
+JSON fields and markdown line content, not full-file snapshots, to keep
+tests resilient to cosmetic changes.
+
+## CLI surface
+
+Exposed as `cowork-mdm skill pack`:
+
+```
+cowork-mdm skill pack INPUT_DIR \
+  --name NAME \
+  --out OUT_DIR \
+  [--version 0.1.0] \
+  [--description "..."] \
+  [--author NAME] \
+  [--author-email EMAIL] \
+  [--force] \
+  [--json]
+```
+
+`--name` and `--out` are required. Text output is a one-liner per skill
+followed by a summary; `--json` emits the `Result` struct verbatim.
+Exits 1 on any Pack error.


### PR DESCRIPTION
## Summary

- New `cowork-mdm skill pack` subcommand — wraps a directory of skills in a minimal plugin bundle so company skill libraries can be delivered via MDM through the same `org-plugins/` mount folder used for regular plugins.
- Cowork's org-plugins/ loader only recognises plugin bundles (dirs with `.claude-plugin/plugin.json`); bare `skills/foo/SKILL.md` is silently ignored. Verified experimentally against Claude.app `1.5354.0` — three probe layouts (bare skill dir, top-level `skills/`, loose `.md`) all failed to load, scanner log `Listed N org plugin(s)` unchanged.
- Crash- and TOCTOU-safe commit: stage to sibling temp dir, then commit via a policy captured at validation time. `outDirAbsent` → plain `os.Rename`. `outDirEmpty` → `syscall.Rmdir` + `os.Rename`. `outDirForceReplace` → sidecar rename + RemoveAll on a path Pack owns, never the user-facing outDir.
- Symlink-safe: canonical inside-input guard via `filepath.EvalSymlinks` (handles broken symlinks), refuses symlinked outDir without --force, resolves symlinks to files on copy, detects cycles via ancestor chain (not global visited).

## What's in the bundle

```
out/
├── .claude-plugin/plugin.json   # reproducible hand-rendered JSON
├── README.md                    # auto-generated, lists all skills
└── skills/
    ├── <skill-a>/SKILL.md
    └── <skill-b>/SKILL.md
```

## Files

- `specs/skillpack.md` — spec
- `internal/skillpack/{skillpack.go,skillpack_test.go}` — implementation + 28 tests
- `cmd/cowork-mdm/cli/skill_cmd.go` — cobra wiring
- `cmd/cowork-mdm/cli/root.go` — registration
- `cmd/cowork-mdm/cli/newcmds_test.go` — CLI help/roundtrip tests

## Review

Reviewed via `/codex:rescue` across 8 rounds. Every MUST-FIX resolved before commit. Final verdict: APPROVED.

## Test plan

- [x] `bash docs/execution/verify.sh task-11` — gofmt + vet + go mod tidy + all 4 cross-compile targets + race-enabled full suite
- [x] `go test ./internal/skillpack/... -race -count=1` — 28 tests pass (layouts, validation, symlink safety, TOCTOU race coverage, cycle detection, reproducibility)
- [x] End-to-end CLI smoke: `cowork-mdm skill pack ./plugin/skills --name internal --out /tmp/b --force` produces correct bundle (5 skills, valid plugin.json, README lists each)
- [ ] Reviewer to drop a packed bundle under `/Library/Application Support/Claude/org-plugins/<name>/` and confirm Cowork loads the skills at next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)