### PR TITLE
feat(profile): gateway templates for DeepSeek / GLM / MiniMax (closes #29)

### DIFF
--- a/internal/profile/golden_gen_test.go
+++ b/internal/profile/golden_gen_test.go
@@ -6,29 +6,39 @@ import (
 	"testing"
 )
 
-// Not a real test — writes the golden file when run with -run GoldenGen.
-// Usage: go test -run TestGoldenGen ./internal/profile/...
-// Commit the resulting file; delete this file after the golden is stable,
-// or keep it to make regeneration a one-liner.
+// Not a real test — writes the golden files when run with -run GoldenGen.
+// Usage: GEN_GOLDEN=1 go test -run TestGoldenGen ./internal/profile/...
+// Commit the resulting files; regenerate whenever the template or encoder
+// shape changes intentionally.
 func TestGoldenGen(t *testing.T) {
 	if os.Getenv("GEN_GOLDEN") != "1" {
-		t.Skip("set GEN_GOLDEN=1 to (re)generate testdata/bedrock-basic.golden.mobileconfig")
+		t.Skip("set GEN_GOLDEN=1 to (re)generate testdata/*.golden.mobileconfig")
 	}
-	p, err := LoadTemplate("bedrock-basic")
-	if err != nil {
-		t.Fatalf("LoadTemplate: %v", err)
+	cases := []struct {
+		template  string
+		file      string
+		payloadID string
+	}{
+		{"bedrock-basic", "bedrock-basic.golden.mobileconfig", "com.example.cowork-mdm.bedrock-basic"},
+		{"gateway-deepseek", "gateway-deepseek.golden.mobileconfig", "com.example.cowork-mdm.gateway-deepseek"},
 	}
-	out, err := EncodeMobileConfig(p, MobileConfigOpts{
-		ConfigurationPayloadUUID: "00000000-0000-4000-8000-000000000000",
-		PayloadUUID:              "11111111-1111-4111-8111-111111111111",
-		PayloadIdentifier:        "com.example.cowork-mdm.bedrock-basic",
-	})
-	if err != nil {
-		t.Fatalf("EncodeMobileConfig: %v", err)
+	for _, tc := range cases {
+		p, err := LoadTemplate(tc.template)
+		if err != nil {
+			t.Fatalf("LoadTemplate %s: %v", tc.template, err)
+		}
+		out, err := EncodeMobileConfig(p, MobileConfigOpts{
+			ConfigurationPayloadUUID: "00000000-0000-4000-8000-000000000000",
+			PayloadUUID:              "11111111-1111-4111-8111-111111111111",
+			PayloadIdentifier:        tc.payloadID,
+		})
+		if err != nil {
+			t.Fatalf("EncodeMobileConfig %s: %v", tc.template, err)
+		}
+		path := filepath.Join("testdata", tc.file)
+		if err := os.WriteFile(path, out, 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", path, err)
+		}
+		t.Logf("wrote %s (%d bytes)", path, len(out))
 	}
-	path := filepath.Join("testdata", "bedrock-basic.golden.mobileconfig")
-	if err := os.WriteFile(path, out, 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	t.Logf("wrote %s (%d bytes)", path, len(out))
 }

--- a/internal/profile/golden_test.go
+++ b/internal/profile/golden_test.go
@@ -41,3 +41,35 @@ func TestEncodeMobileConfig_GoldenBedrockBasic(t *testing.T) {
 			string(want), string(got))
 	}
 }
+
+// TestEncodeMobileConfig_GoldenGatewayDeepseek pins the byte-exact output
+// for the gateway-deepseek template. One gateway vendor is enough to lock
+// the encoder shape; per-vendor baseURL / auth scheme drift is caught by
+// TestLoadTemplate_GatewayVendors at the Profile level.
+//
+// Regenerate via: GEN_GOLDEN=1 go test -run TestGoldenGen ./internal/profile/...
+func TestEncodeMobileConfig_GoldenGatewayDeepseek(t *testing.T) {
+	path := filepath.Join("testdata", "gateway-deepseek.golden.mobileconfig")
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden: %v (run GEN_GOLDEN=1 go test -run TestGoldenGen ... to create it)", err)
+	}
+	p, err := LoadTemplate("gateway-deepseek")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	got, err := EncodeMobileConfig(p, MobileConfigOpts{
+		ConfigurationPayloadUUID: "00000000-0000-4000-8000-000000000000",
+		PayloadUUID:              "11111111-1111-4111-8111-111111111111",
+		PayloadIdentifier:        "com.example.cowork-mdm.gateway-deepseek",
+	})
+	if err != nil {
+		t.Fatalf("EncodeMobileConfig: %v", err)
+	}
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
+	got = bytes.ReplaceAll(got, []byte("\r\n"), []byte("\n"))
+	if !bytes.Equal(want, got) {
+		t.Errorf("gateway-deepseek golden drift — diff:\nWANT:\n%s\n\nGOT:\n%s",
+			string(want), string(got))
+	}
+}

--- a/internal/profile/templates/gateway-deepseek.yaml
+++ b/internal/profile/templates/gateway-deepseek.yaml
@@ -1,0 +1,36 @@
+name: gateway-deepseek
+description: |
+  Claude Desktop pointed at DeepSeek's Anthropic-compatible endpoint via
+  inferenceProvider=gateway. Replace the API key placeholder with the token
+  your IT team issues from DeepSeek's console before deploying.
+
+  # Source: https://api-docs.deepseek.com/guides/anthropic_api
+  #   - base URL: https://api.deepseek.com/anthropic
+  #   - auth header: x-api-key (env var ANTHROPIC_API_KEY in their docs)
+  #
+  # Companion step: this template only carries LLM config. To also deliver
+  # company skills / slash commands / MCPs, run (after profile apply):
+  #   cowork-mdm marketplace add https://github.com/<your-org>/claude-org-plugins
+  # which clones the repo into /Library/Application Support/Claude/org-plugins/
+  # and symlinks each plugin into place. See `mdm-plugins` skill for details.
+
+values:
+  inferenceProvider: gateway
+
+  disableDeploymentModeChooser: true
+
+  inferenceGatewayBaseUrl: https://api.deepseek.com/anthropic
+
+  # DeepSeek's Anthropic-compatible endpoint accepts x-api-key (per its doc's
+  # "Fully Supported" compatibility table).
+  inferenceGatewayAuthScheme: x-api-key
+
+  # Replace with the token from DeepSeek's console. Never commit real keys to
+  # this template — keep them in your private overrides YAML instead.
+  inferenceGatewayApiKey: REPLACE_WITH_YOUR_API_KEY
+
+  # Optional: pin a model list. Without this the gateway's /v1/models result
+  # is used. DeepSeek's doc example cites deepseek-v4-pro; unrecognized names
+  # fall back server-side to deepseek-v4-flash.
+  # inferenceModels: >-
+  #   ["deepseek-v4-pro","deepseek-v4-flash"]

--- a/internal/profile/templates/gateway-glm.yaml
+++ b/internal/profile/templates/gateway-glm.yaml
@@ -1,0 +1,36 @@
+name: gateway-glm
+description: |
+  Claude Desktop pointed at Zhipu GLM's Anthropic-compatible endpoint via
+  inferenceProvider=gateway. Replace the API key placeholder with the token
+  your IT team issues from Zhipu's console (open.bigmodel.cn) before
+  deploying.
+
+  # Source: https://docs.bigmodel.cn/cn/guide/develop/claude
+  #   - base URL: https://open.bigmodel.cn/api/anthropic
+  #   - auth: env var ANTHROPIC_AUTH_TOKEN → Authorization: Bearer
+  #
+  # Companion step: this template only carries LLM config. To also deliver
+  # company skills / slash commands / MCPs, run (after profile apply):
+  #   cowork-mdm marketplace add https://github.com/<your-org>/claude-org-plugins
+  # which clones the repo into /Library/Application Support/Claude/org-plugins/
+  # and symlinks each plugin into place. See `mdm-plugins` skill for details.
+
+values:
+  inferenceProvider: gateway
+
+  disableDeploymentModeChooser: true
+
+  inferenceGatewayBaseUrl: https://open.bigmodel.cn/api/anthropic
+
+  # Zhipu's doc sets ANTHROPIC_AUTH_TOKEN, which Claude Code wires as
+  # Authorization: Bearer.
+  inferenceGatewayAuthScheme: bearer
+
+  # Replace with the token from Zhipu's console. Never commit real keys to
+  # this template — keep them in your private overrides YAML instead.
+  inferenceGatewayApiKey: REPLACE_WITH_YOUR_API_KEY
+
+  # Optional: pin a model list. Without this the gateway's /v1/models result
+  # is used. Zhipu's doc examples reference these Anthropic-compatible names.
+  # inferenceModels: >-
+  #   ["glm-5.1","GLM-4.7","GLM-4.5-Air","glm-5-turbo"]

--- a/internal/profile/templates/gateway-minimax.yaml
+++ b/internal/profile/templates/gateway-minimax.yaml
@@ -1,0 +1,34 @@
+name: gateway-minimax
+description: |
+  Claude Desktop pointed at MiniMax's Anthropic-compatible endpoint via
+  inferenceProvider=gateway. Replace the API key placeholder with the token
+  your IT team issues from MiniMax's platform console before deploying.
+
+  # Source: https://platform.minimaxi.com/docs/api-reference/text-anthropic-api
+  #   - base URL: https://api.minimaxi.com/anthropic
+  #   - auth: env var ANTHROPIC_API_KEY → x-api-key header
+  #
+  # Companion step: this template only carries LLM config. To also deliver
+  # company skills / slash commands / MCPs, run (after profile apply):
+  #   cowork-mdm marketplace add https://github.com/<your-org>/claude-org-plugins
+  # which clones the repo into /Library/Application Support/Claude/org-plugins/
+  # and symlinks each plugin into place. See `mdm-plugins` skill for details.
+
+values:
+  inferenceProvider: gateway
+
+  disableDeploymentModeChooser: true
+
+  inferenceGatewayBaseUrl: https://api.minimaxi.com/anthropic
+
+  # MiniMax's doc sets ANTHROPIC_API_KEY, which corresponds to x-api-key.
+  inferenceGatewayAuthScheme: x-api-key
+
+  # Replace with the token from MiniMax's platform console. Never commit real
+  # keys to this template — keep them in your private overrides YAML instead.
+  inferenceGatewayApiKey: REPLACE_WITH_YOUR_API_KEY
+
+  # Optional: pin a model list. Without this the gateway's /v1/models result
+  # is used. Names below are from MiniMax's Anthropic-compatible doc.
+  # inferenceModels: >-
+  #   ["MiniMax-M2.7","MiniMax-M2.7-highspeed","MiniMax-M2.5","MiniMax-M2.1"]

--- a/internal/profile/templates_test.go
+++ b/internal/profile/templates_test.go
@@ -1,13 +1,23 @@
 package profile
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
 
-func TestTemplateNames_IncludesAllFive(t *testing.T) {
+func TestTemplateNames_IncludesAll(t *testing.T) {
 	names := TemplateNames()
-	want := []string{"bedrock-basic", "foundry", "gateway", "mcp-only", "vertex"}
+	want := []string{
+		"bedrock-basic",
+		"foundry",
+		"gateway",
+		"gateway-deepseek",
+		"gateway-glm",
+		"gateway-minimax",
+		"mcp-only",
+		"vertex",
+	}
 	if len(names) != len(want) {
 		t.Fatalf("TemplateNames() = %v, want %v", names, want)
 	}
@@ -124,5 +134,72 @@ values:
 	_, err := LoadTemplateFile(raw)
 	if err == nil || !strings.Contains(err.Error(), "name") {
 		t.Errorf("expected name-missing error, got %v", err)
+	}
+}
+
+func TestLoadTemplate_GatewayVendors(t *testing.T) {
+	cases := []struct {
+		name       string
+		baseURL    string
+		authScheme string
+	}{
+		{"gateway-deepseek", "https://api.deepseek.com/anthropic", "x-api-key"},
+		{"gateway-glm", "https://open.bigmodel.cn/api/anthropic", "bearer"},
+		{"gateway-minimax", "https://api.minimaxi.com/anthropic", "x-api-key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := LoadTemplate(tc.name)
+			if err != nil {
+				t.Fatalf("LoadTemplate %s: %v", tc.name, err)
+			}
+			if v, _ := p.Get("inferenceProvider"); v != "gateway" {
+				t.Errorf("inferenceProvider = %v, want gateway", v)
+			}
+			if v, _ := p.Get("inferenceGatewayBaseUrl"); v != tc.baseURL {
+				t.Errorf("inferenceGatewayBaseUrl = %v, want %q", v, tc.baseURL)
+			}
+			if v, _ := p.Get("inferenceGatewayAuthScheme"); v != tc.authScheme {
+				t.Errorf("inferenceGatewayAuthScheme = %v, want %q", v, tc.authScheme)
+			}
+			// API key must be the placeholder — regression guard against
+			// accidentally committing a real vendor key to a shipped template.
+			v, _ := p.Get("inferenceGatewayApiKey")
+			key, _ := v.(string)
+			if !strings.Contains(key, "REPLACE_WITH_YOUR_API_KEY") {
+				t.Errorf("inferenceGatewayApiKey = %q, want REPLACE_WITH_YOUR_API_KEY placeholder", key)
+			}
+		})
+	}
+}
+
+func TestLoadTemplate_NoLeakedKeysInGatewayTemplates(t *testing.T) {
+	// Regression guard: the three CN-vendor gateway templates must never
+	// carry a real key. Scan the raw embedded YAML for key-shaped patterns.
+	// Each regex targets a concrete vendor-key prefix + enough entropy to
+	// be unmistakably a real secret, not a prose mention (e.g. "sk-" alone
+	// would false-positive on words like "sk-SNAPSHOT" in a comment).
+	leakPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`sk-[A-Za-z0-9_\-]{20,}`),         // OpenAI / DeepSeek / Anthropic test keys
+		regexp.MustCompile(`Bearer\s+ey[A-Za-z0-9_\-]{20,}`), // JWT literal
+		regexp.MustCompile(`xai-[A-Za-z0-9]{20,}`),           // xAI
+		regexp.MustCompile(`gsk_[A-Za-z0-9]{20,}`),           // Groq
+	}
+	for _, name := range []string{"gateway-deepseek", "gateway-glm", "gateway-minimax"} {
+		t.Run(name, func(t *testing.T) {
+			raw, err := templateFS.ReadFile("templates/" + name + ".yaml")
+			if err != nil {
+				t.Fatalf("read template: %v", err)
+			}
+			text := string(raw)
+			if !strings.Contains(text, "REPLACE_WITH_YOUR_API_KEY") {
+				t.Errorf("%s must contain REPLACE_WITH_YOUR_API_KEY placeholder", name)
+			}
+			for _, re := range leakPatterns {
+				if m := re.FindString(text); m != "" {
+					t.Errorf("%s contains leaked-key match %q — review template before shipping", name, m)
+				}
+			}
+		})
 	}
 }

--- a/internal/profile/testdata/gateway-deepseek.golden.mobileconfig
+++ b/internal/profile/testdata/gateway-deepseek.golden.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.anthropic.claudefordesktop</string>
+			<key>PayloadIdentifier</key>
+			<string>com.example.cowork-mdm.gateway-deepseek.settings</string>
+			<key>PayloadUUID</key>
+			<string>11111111-1111-4111-8111-111111111111</string>
+			<key>PayloadDisplayName</key>
+			<string>gateway-deepseek</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>disableDeploymentModeChooser</key>
+			<true/>
+			<key>inferenceGatewayApiKey</key>
+			<string>REPLACE_WITH_YOUR_API_KEY</string>
+			<key>inferenceGatewayAuthScheme</key>
+			<string>x-api-key</string>
+			<key>inferenceGatewayBaseUrl</key>
+			<string>https://api.deepseek.com/anthropic</string>
+			<key>inferenceProvider</key>
+			<string>gateway</string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>gateway-deepseek</string>
+	<key>PayloadIdentifier</key>
+	<string>com.example.cowork-mdm.gateway-deepseek</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>00000000-0000-4000-8000-000000000000</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadScope</key>
+	<string>System</string>
+</dict>
+</plist>

--- a/plugin/commands/new-profile.md
+++ b/plugin/commands/new-profile.md
@@ -52,11 +52,16 @@ the user.
 
 ### 4. Generate and validate
 
+`--template` and `--from` are **mutually exclusive**. Pick one based on
+whether the user has enterprise-specific values to plug in:
+
 ```bash
-cowork-mdm profile new \
-  --template <provider> \
-  --from overrides.yaml \
-  --out profile.mobileconfig
+# No enterprise overrides — emit a template verbatim (useful for previews):
+cowork-mdm profile new --template <provider> --out profile.mobileconfig
+
+# With enterprise overrides (ARNs, tokens, MCP list) — use your own YAML:
+cowork-mdm profile new --from overrides.yaml --out profile.mobileconfig
+
 cowork-mdm profile validate profile.mobileconfig
 ```
 
@@ -70,6 +75,25 @@ spot-check. Tell them the next step is **not** local apply — it's handing
 the file to their MDM (Jamf/Intune/Kandji). If they want to test locally
 on this very Mac, suggest `/cowork-mdm:deploy profile.mobileconfig` which
 runs a dry-run preview without touching disk.
+
+### 6. Offer companion plugin-marketplace install
+
+A profile carries LLM + MCP config but not skills or slash commands.
+After validate succeeds, **ask** the user whether they also want to install
+the org's plugin marketplace (which delivers skills / slash commands / MCPs
+via `org-plugins/`). Do not assume yes. If the user confirms and supplies
+the marketplace URL, run:
+
+```bash
+cowork-mdm marketplace add <url>
+cowork-mdm plugin list
+```
+
+`marketplace add` writes under `/Library/Application Support/Claude/
+org-plugins/`, which typically requires sudo — **do not** run sudo on the
+user's behalf. If the command errors with permission denied, tell the user
+exactly which command to re-run with `sudo` and stop. If the org hasn't
+published a plugin marketplace yet, skip this step silently.
 
 ### Rules
 

--- a/plugin/skills/mdm-profile-authoring/SKILL.md
+++ b/plugin/skills/mdm-profile-authoring/SKILL.md
@@ -82,7 +82,7 @@ shipped in the binary and are meant to be provider-neutral scaffolds.
 Enterprise-specific values (ARNs, MCP tokens, allowed-host lists) belong
 in your private `overrides.yaml`.
 
-## The five built-in templates
+## The built-in templates
 
 `cowork-mdm profile templates` prints the current list. As of v0.3:
 
@@ -92,7 +92,39 @@ in your private `overrides.yaml`.
 | `vertex` | Google Vertex AI | project id, region, model IDs |
 | `foundry` | Azure Foundry | endpoint, deployment names |
 | `gateway` | Generic OpenAI-compatible gateway (LLM proxy) | base URL, auth header, model list |
+| `gateway-deepseek` | DeepSeek Anthropic-compatible endpoint | API key; optional `inferenceModels` override |
+| `gateway-glm` | Zhipu GLM Anthropic-compatible endpoint | API key; optional `inferenceModels` override |
+| `gateway-minimax` | MiniMax Anthropic-compatible endpoint | API key; optional `inferenceModels` override |
 | `mcp-only` | No inference override, only locks MCP + egress | `managedMcpServers`, `coworkEgressAllowedHosts` |
+
+The three `gateway-*` CN-vendor templates each pre-bake `inferenceGatewayBaseUrl`
+and `inferenceGatewayAuthScheme` so IT admins only need to supply an API key.
+They're convenience wrappers over the generic `gateway` template and point at
+the vendor's documented Anthropic-compatible endpoint.
+
+### Pair with a plugin marketplace
+
+A profile delivers **LLM config** (`inferenceProvider`, gateway URL, model
+list) and **MCP config** (`managedMcpServers`) — but **not** skills or slash
+commands. Those live in Claude Desktop's `org-plugins/` directory and are
+delivered via the plugin-marketplace pathway:
+
+```bash
+# After `cowork-mdm profile apply` (or the MDM push) lands on the machine:
+cowork-mdm marketplace add https://github.com/<your-org>/claude-org-plugins
+cowork-mdm marketplace update                # later, to refresh
+cowork-mdm plugin list                       # verify what resolved
+```
+
+This clones the org's plugin-marketplace repo into
+`/Library/Application Support/Claude/org-plugins/` and creates top-level
+symlinks for every plugin it discovers. Anthropic's marketplace layout
+(`.claude-plugin/marketplace.json` + `plugins/<name>/...`) is what
+`marketplace add` expects; see `mdm-plugins` skill for details.
+
+If the user's goal is **full enterprise onboarding** (LLM + MCP + skills +
+slash commands), the profile is only half the job — remind the user to also
+run `marketplace add` with their org's plugin repo.
 
 ## Overrides YAML shape
 


### PR DESCRIPTION
## Summary

Adds three vendor-preset gateway templates so IT admins can generate a deployable `.mobileconfig` for Claude Desktop against a Chinese LLM provider's Anthropic-compatible endpoint with one command.

| Template | Base URL | Auth scheme |
| --- | --- | --- |
| `gateway-deepseek` | `https://api.deepseek.com/anthropic` | `x-api-key` |
| `gateway-glm` | `https://open.bigmodel.cn/api/anthropic` | `bearer` |
| `gateway-minimax` | `https://api.minimaxi.com/anthropic` | `x-api-key` |

Each template leaves `inferenceGatewayApiKey` as `REPLACE_WITH_YOUR_API_KEY` and carries a `# Source:` comment pointing at the vendor doc it was populated from.

Each template also carries a `# Companion step:` header explaining that profiles deliver LLM + MCP config but not skills / slash commands — those ship separately via `cowork-mdm marketplace add <org-plugins-repo>`. The authoring SKILL.md and the `/cowork-mdm:new-profile` slash command playbook pick up the same pairing so an agent driving the CLI remembers to offer both halves of enterprise onboarding.

Incidental fix: `plugin/commands/new-profile.md` step 4 previously combined `--template` and `--from` in one invocation, which the CLI rejects as mutually exclusive. Split into two side-by-side alternatives.

## What's new

- `internal/profile/templates/gateway-{deepseek,glm,minimax}.yaml`
- `internal/profile/testdata/gateway-deepseek.golden.mobileconfig`
- `TestTemplateNames_IncludesAll` → now covers 8 templates
- `TestLoadTemplate_GatewayVendors` — table-driven per-vendor base URL + auth scheme + placeholder assertions
- `TestLoadTemplate_NoLeakedKeysInGatewayTemplates` — compiled regex (≥20 entropy chars after vendor prefix) to guard against accidental real-key commits
- `TestEncodeMobileConfig_GoldenGatewayDeepseek` — byte-exact encoder lock for one representative vendor
- `plugin/skills/mdm-profile-authoring/SKILL.md` — template table grows to 8 rows + "Pair with a plugin marketplace" subsection
- `plugin/commands/new-profile.md` — added step 6 "Offer companion plugin-marketplace install" (asks, never assumes yes, never sudos)

## Non-goals

- No new schema keys; everything fits into the existing 51-key surface.
- No `enterprise-cn-full` combo template — that's issue #30.
- No research into MDM-native skill/plugin pushing — that's issue #31.
- No live vendor smoke test in CI (can't ship API keys).
- No plist/reg/intune/jamf goldens for the new templates — those encoders are tracked in #7/#8/#9.

## Test plan

- [x] `go test ./internal/profile/...` green
- [x] `docs/execution/verify.sh task-03` green (gofmt, vet, tidy, cross-build darwin+windows+linux, full `-race` suite, plutil -lint on both goldens)
- [x] `cowork-mdm profile templates` lists 8 entries including the three new ones
- [x] For each vendor: `profile new --template gateway-<vendor>` succeeds, `profile validate` passes, output contains the vendor URL
- [x] Sparring-reviewed (plan + code) per `CLAUDE.md` 铁律; both rounds APPROVE

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)