### PR TITLE
feat(profile+docs): enterprise-cn-full template + CN deployment cookbook (closes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ cowork-mdm doctor --fix
 Every subcommand accepts `--json` for machine-readable output. Spec and
 task breakdown: [`specs/`](specs/) + [`docs/execution/TASKS.md`](docs/execution/TASKS.md).
 
+## Enterprise deployment
+
+**Chinese LLM providers (DeepSeek / GLM / MiniMax) + MDM fleet rollout**:
+see [docs/deployment-cn.md](docs/deployment-cn.md) for the full cookbook
+covering Jamf / Intune / Kandji distribution, the `enterprise-cn-full`
+template, and the Script-payload pattern for shipping company plugins
+alongside the mobileconfig.
+
 ## Use as a Claude Code plugin
 
 v0.3 adds a Claude Code plugin layer: five skills + four slash commands

--- a/docs/deployment-cn.md
+++ b/docs/deployment-cn.md
@@ -1,0 +1,370 @@
+# Claude Desktop enterprise deployment — Chinese LLM providers
+
+End-to-end recipe for taking Claude Desktop from "fresh Mac" to "employee
+logged in, talking to the company-approved Chinese LLM with company MCP
+servers and company skills/commands". Target audience: enterprise IT /
+ops running Jamf Pro, Microsoft Intune, or Kandji for macOS fleets.
+
+Scope: macOS. Windows is not yet supported end-to-end (tracked in
+[issue #9](https://github.com/krislavten/cowork-mdm/issues/9)).
+
+> **Key fact up front**: a `.mobileconfig` (the MDM-native channel)
+> delivers LLM + standalone MCP + telemetry + sandbox policy only. It
+> **cannot** deliver skills, slash commands, hooks, or plugin-bundled
+> MCPs — see [`docs/research/skills-plugins-mdm.md`](research/skills-plugins-mdm.md)
+> for the reverse-engineered evidence. Full onboarding therefore
+> combines an MDM mobileconfig push with a Script payload that runs
+> `cowork-mdm marketplace add <org-plugins-repo>`. Section 5 shows both.
+
+## 1. Prerequisites
+
+Before starting, gather:
+
+- **Vendor API key.** Created on the vendor's platform console (DeepSeek,
+  Zhipu GLM, or MiniMax). You'll inject this via your MDM's secret-variable
+  mechanism, not by hand-pasting into a YAML file.
+- **Admin access to your MDM system** (Jamf Pro / Intune / Kandji) —
+  specifically the permission to push a Custom Settings Payload + a
+  Shell Script payload, both scoped to the target device group.
+- **List of your internal MCP server endpoints.** Typically `https://
+  mcp.<your-org>.internal/<service>` entries. Each needs `{name, url,
+  transport}` and optionally `toolPolicy` (see
+  `cowork-mdm schema show managedMcpServers`).
+- **Optional but recommended — a plugin marketplace repo.** A git repo
+  following [Anthropic's marketplace layout](https://code.claude.com/docs/en/plugin-marketplaces)
+  (`.claude-plugin/marketplace.json` + `plugins/<name>/...`). This is
+  how skills / slash commands / hooks reach employee machines. Without
+  one, the Script payload step in Section 5 is skipped and you ship LLM
+  config only.
+- **A macOS 13+ test machine** you can enroll in your MDM's staging group
+  to verify the deployment end-to-end before rolling to the fleet.
+- **`cowork-mdm` CLI installed locally** (`brew install
+  krislavten/tap/cowork-mdm`). You need it to generate, validate, and
+  preview the profile on the admin workstation before pushing.
+
+## 2. Pick your LLM provider
+
+Pre-baked templates cover the three domestic providers with Anthropic-
+compatible endpoints. Pick one and note its values — you'll use them in
+Section 3.
+
+| Vendor      | Template (if using one)    | `inferenceGatewayBaseUrl`                 | `inferenceGatewayAuthScheme` |
+| ----------- | -------------------------- | ----------------------------------------- | ---------------------------- |
+| DeepSeek    | `gateway-deepseek`         | `https://api.deepseek.com/anthropic`      | `x-api-key`                  |
+| Zhipu GLM   | `gateway-glm`              | `https://open.bigmodel.cn/api/anthropic`  | `bearer`                     |
+| MiniMax     | `gateway-minimax`          | `https://api.minimaxi.com/anthropic`      | `x-api-key`                  |
+
+If you only need LLM config — no MCP, no egress lockdown — use the
+per-vendor template directly:
+
+```bash
+cowork-mdm profile new --template gateway-deepseek --out lite.mobileconfig
+```
+
+Then edit the generated file to drop in the real API key (or better,
+use `--from my.yaml` so the key never lands in the template). For
+full enterprise scaffolding (MCP + egress + telemetry + sandbox +
+auto-update policy), continue to Section 3 with `enterprise-cn-full`.
+
+## 3. Generate the profile
+
+### 3a. `--template` is a scaffold, not a production profile
+
+`cowork-mdm profile new --template enterprise-cn-full --out out.mobileconfig`
+will produce a valid `.mobileconfig` — but **every `REPLACE_*` string in
+the output is still a placeholder**. `profile validate` will pass because
+placeholders are syntactically valid strings; the profile is not yet
+deployable. Do not distribute a template-emitted file to employee
+machines.
+
+### 3b. Production path — copy, fill, `--from`
+
+The CLI's `profile new` emits `mobileconfig` or `plist` only (see
+`profile new --format`), not YAML. To get an editable YAML starting
+point, copy the template source from the installed CLI's release
+bundle — the version pinned to the CLI you have locally:
+
+```bash
+# `cowork-mdm --version` prints e.g. `cowork-mdm version 0.3.0 (commit …, built …)`.
+# Extract the 3rd token as the semver tag.
+VERSION=$(cowork-mdm --version | awk '{print $3}')
+curl -L -o overrides.yaml \
+  "https://raw.githubusercontent.com/krislavten/cowork-mdm/v${VERSION}/internal/profile/templates/enterprise-cn-full.yaml"
+```
+
+Pinning to `v${VERSION}` (not `main`) keeps the YAML in lock-step with
+the CLI; `main` can diverge between releases and break `profile new`.
+
+```bash
+# 1. Replace every REPLACE_* placeholder in overrides.yaml with your
+#    real values: gateway base URL + auth scheme + API key, model IDs,
+#    MCP server list, egress allowlist, and any optional sandbox flags
+#    you want to enable.
+
+# 2. Generate the mobileconfig.
+cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
+```
+
+`--template` and `--from` are mutually exclusive on a single
+invocation — pick one. (Follow-up issue for a `profile show-template
+<name>` dump-source subcommand tracked at time of writing — until
+it ships, `curl` is the supported path.)
+
+### 3c. Inject the API key via MDM, not YAML
+
+If your MDM supports secret variables (Jamf: `$MANAGED_SECRETS`, Intune:
+app-config variables, Kandji: parameters), substitute them in at push
+time rather than at profile-build time. Two patterns work:
+
+1. **Pre-build substitution**: envsubst + CI. Your CI pipeline reads
+   the API key from a secrets store, runs `envsubst` over
+   `overrides.yaml`, produces `company.mobileconfig`, and publishes the
+   file to a private artifact store the MDM pulls from.
+2. **Per-machine substitution** (Jamf): leave the gateway API key blank
+   in the pushed mobileconfig and use `inferenceCredentialHelper` to
+   point at a shell script the MDM also pushes, which fetches the key
+   per-user from your secrets service. See `cowork-mdm schema show
+   inferenceCredentialHelper`.
+
+Pattern 1 is simpler; pattern 2 avoids baking a shared secret into the
+distributed mobileconfig.
+
+## 4. Validate
+
+```bash
+cowork-mdm profile validate company.mobileconfig
+```
+
+Expected output on success: `company.mobileconfig: OK (N keys)` with a
+non-zero `N`. On failure, the command prints the offending key and
+exits non-zero.
+
+**`validate` is schema-only.** It checks that keys exist in the 51-key
+schema, values match their declared types, and `jsonString` fields are
+parseable. It does NOT check:
+
+- Whether any `REPLACE_*` placeholder strings remain in the output.
+- Whether the vendor API key is actually valid with the vendor.
+- Whether MCP servers are reachable from employee machines.
+- Whether the profile is signed (required by some MDMs — see Section 5).
+
+Add a placeholder check to your pre-distribution pipeline:
+
+```bash
+if grep -q "REPLACE_" company.mobileconfig; then
+  echo "ERROR: unfilled placeholders in profile — do not distribute"
+  exit 1
+fi
+```
+
+## 5. Distribute via MDM
+
+All three MDM systems follow the same two-wave pattern:
+
+- **Wave 1**: push `company.mobileconfig` as a Custom Settings Payload,
+  scoped to the target device group. This lands LLM + MCP + egress +
+  telemetry + sandbox settings.
+- **Wave 2**: push a Shell Script payload that runs
+  `cowork-mdm marketplace add <org-plugins-repo>`. This populates
+  `/Library/Application Support/Claude/org-plugins/` with your skills
+  and slash commands.
+
+Both waves should target the same device group and run on the same
+cadence. Wave 2 can also run later as an update path (see Section 8).
+
+### 5a. Jamf Pro
+
+**Wave 1 (mobileconfig)**
+1. **Settings → Computer Management → Configuration Profiles → + New**
+2. **Scope**: target your Smart Group (e.g. "Claude Desktop Eligible Macs").
+3. **Payload**: *Application & Custom Settings → Custom Schema →
+   Upload...* Load `company.mobileconfig`. Preference Domain must be
+   `com.anthropic.claudefordesktop` (the cowork-mdm encoder sets this
+   automatically).
+4. **Save**. Jamf distributes at the next check-in (usually ≤15
+   minutes).
+
+**Wave 2 (Script payload for plugin delivery)**
+1. **Settings → Computer Management → Scripts → + New**
+2. Body (assumes cowork-mdm is installed via brew or deployed via your
+   own package). The script resolves the CLI path across Intel +
+   Apple Silicon brew layouts and idempotently adds + updates the
+   marketplace:
+   ```bash
+   #!/bin/bash
+   set -euo pipefail
+
+   # Resolve the cowork-mdm binary across common install locations.
+   # Override via COWORK_MDM_BIN if your org installs somewhere else.
+   CLI="${COWORK_MDM_BIN:-}"
+   if [ -z "$CLI" ]; then
+     for candidate in /opt/homebrew/bin/cowork-mdm /usr/local/bin/cowork-mdm; do
+       [ -x "$candidate" ] && CLI="$candidate" && break
+     done
+   fi
+   [ -z "$CLI" ] && CLI="$(command -v cowork-mdm || true)"
+   [ -z "$CLI" ] && { echo "cowork-mdm not found" >&2; exit 127; }
+
+   ORG_URL="https://github.com/<your-org>/claude-org-plugins"
+
+   # Idempotent add; `marketplace add` fails if already added.
+   if ! "$CLI" marketplace list --json 2>/dev/null \
+        | /usr/bin/grep -q "<your-org>/claude-org-plugins"; then
+     "$CLI" marketplace add "$ORG_URL"
+   fi
+
+   # Pull any new plugins the org has published since last run.
+   "$CLI" marketplace update
+   "$CLI" plugin list
+   ```
+3. **Policy → New** that runs the script, scoped to the same Smart
+   Group.
+4. Trigger: *Recurring Check-in* (so new plugins get picked up and the
+   directory self-heals if wiped).
+
+### 5b. Microsoft Intune for macOS
+
+**Wave 1 (mobileconfig)**
+1. **Devices → macOS → Configuration profiles → + Create profile**
+2. **Profile type**: *Templates → Preference file*.
+3. Upload `company.mobileconfig`. Preference domain auto-detected.
+4. **Assignments**: target your macOS device group.
+
+**Wave 2 (Shell script payload)**
+1. **Devices → macOS → Shell scripts → + Add**
+2. Paste the Bash body from 5a. Run as root. Frequency: *every 1 day*
+   is safe (the `marketplace list | grep` guard makes it idempotent).
+3. Assignments: same device group.
+
+### 5c. Kandji
+
+**Wave 1 (mobileconfig)**
+1. **Library → Add New → Custom Profile**
+2. Upload `company.mobileconfig`. Assign to Blueprint.
+
+**Wave 2 (Custom Script)**
+1. **Library → Add New → Custom Script**
+2. Paste the Bash body from 5a. Execution: *Every 1 day* + *On
+   Enrollment*. Assign to the same Blueprint.
+
+### 5d. Delivering skills, slash commands, and plugin-bundled MCPs
+
+Standalone MCP servers go in the mobileconfig via `managedMcpServers`.
+But **skills, slash commands, hooks, and plugin-bundled MCPs do not
+ship inside the mobileconfig.** Claude Desktop reads those from its
+local `/Library/Application Support/Claude/org-plugins/` directory.
+That directory is populated in one of three ways:
+
+1. **End user runs `/plugin marketplace add <url>`** inside Claude Desktop.
+2. **IT pre-populates via `cowork-mdm marketplace add <url>`** on first setup. This clones the git repo into `org-plugins/` and symlinks each plugin it finds.
+3. **MDM runs `cowork-mdm marketplace add <url>` as a scripted payload** on the same cadence as the mobileconfig push. This is what Sections 5a–5c above implement.
+
+The mobileconfig carries **LLM config** (`inferenceProvider`, gateway
+URL, model list) and **standalone MCP config** (`managedMcpServers`) —
+not skills, not plugins, and not plugin-bundled MCPs. `bootstrapUrl`
+cannot deliver skills or plugins either: its JSON response is filtered
+by a compile-time allowlist that only admits LLM and OTLP keys. See
+[`docs/research/skills-plugins-mdm.md`](research/skills-plugins-mdm.md)
+for the reverse-engineered evidence.
+
+### 5e. Windows
+
+Not yet supported end-to-end. The `.reg` encoder is tracked in
+[#9](https://github.com/krislavten/cowork-mdm/issues/9); `org-plugins`
+path and symlink support on Windows are tracked alongside. For now,
+macOS-only fleets are the supported target.
+
+## 6. Verify on an employee machine
+
+After the MDM has had time to sync (15 min for Jamf, up to an hour for
+Intune), SSH into a test Mac and run the operational readiness checklist:
+
+```bash
+# 1. Profile is installed at the expected scope.
+#    Expected JSON: {"platform":"darwin", "present":true,
+#    "targetPath":"/Library/Managed Preferences/com.anthropic.claudefordesktop.plist",
+#    "profile":{...}}
+cowork-mdm profile status --json | python3 -c '
+import json, sys
+s = json.load(sys.stdin)
+if not s.get("present"):
+    print("FAIL: no managed profile present")
+    sys.exit(1)
+print(f"OK: profile present at {s[\"targetPath\"]}")
+'
+
+# 2. No REPLACE_ placeholders leaked into production.
+#    Claude Desktop's managed plist lives at one of these two paths
+#    (host-wide or per-user); check both.
+USER_PLIST="/Library/Managed Preferences/$USER/com.anthropic.claudefordesktop.plist"
+HOST_PLIST="/Library/Managed Preferences/com.anthropic.claudefordesktop.plist"
+LEAKED=0
+for f in "$USER_PLIST" "$HOST_PLIST"; do
+  if [ -f "$f" ] && /usr/bin/plutil -convert xml1 -o - "$f" 2>/dev/null | /usr/bin/grep -q "REPLACE_"; then
+    echo "FAIL: placeholder in $f"
+    LEAKED=1
+  fi
+done
+[ "$LEAKED" -eq 0 ] && echo "OK: no placeholders in deployed plist"
+
+# 3. Plugins landed in org-plugins/.
+#    Expected: non-empty output. Empty = Script payload (5a/b/c) didn't
+#              run, or failed. See Section 7.
+cowork-mdm plugin list
+
+# 4. System health.
+#    Expected: no P0 findings. P1/P2 warnings are informational.
+cowork-mdm doctor
+```
+
+If all four return clean, the deployment is working. Roll to the rest
+of the fleet.
+
+`plutil -convert xml1 -o -` handles both XML and binary plist formats;
+`PlistBuddy -c Print` works too but omits raw values in some cases.
+
+## 7. Common failure modes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Claude Desktop shows 401 on first LLM request | `inferenceGatewayAuthScheme` mismatch with vendor (e.g. set `bearer` but vendor wants `x-api-key`) | Check Section 2 table; regenerate mobileconfig; re-push. |
+| Claude Desktop can't reach MCP server | MCP host not in `coworkEgressAllowedHosts` | Add the host, regenerate, re-push. Wildcard: `"*.internal.example.com"`. |
+| MCP server reachable but tool calls fail silently | MCP server unreachable from the user's sandbox (firewall, DNS) | Run `curl` from inside Claude Desktop's built-in terminal to confirm. |
+| `cowork-mdm plugin list` returns empty on employee Mac | Wave 2 Script payload didn't run or `marketplace add` failed (permission denied, network block, auth on the git host) | Check the MDM's script log on the machine. Re-run manually: `sudo cowork-mdm marketplace add <url>`. Verify `/Library/Application Support/Claude/org-plugins/` is writable by root. |
+| Profile not active even after MDM sync | `managedappconfigd` hasn't synced, or the Custom Settings payload targeted the wrong preference domain | Force sync: `sudo profiles sync`. Confirm domain is `com.anthropic.claudefordesktop`. |
+| New profile version pushed but Claude Desktop still shows old config | Claude Desktop may cache managed config at launch (not independently verified as of v0.3) | First confirm the new plist is live: `cowork-mdm profile status --json` on the Mac should show the new values. If it does and Claude Desktop still doesn't reflect them, have the user quit and relaunch Claude Desktop. If that's a recurring issue across your fleet, you can optionally push a "Restart Claude Desktop" follow-up script after each mobileconfig update. |
+| `profile validate` passes but profile is clearly broken on the Mac | Validate is schema-only — see Section 4. Placeholder string, invalid token, or MCP JSON escape issue. | Re-check YAML against actual vendor console output. |
+
+## 8. Updating later
+
+- **To rotate the API key or change a model list**: edit `overrides.yaml`,
+  re-generate, re-validate, push as a new mobileconfig version (bump the
+  `PayloadVersion` integer). MDM redelivers the new payload; Claude
+  Desktop picks it up on next launch.
+- **To ship new plugins / skills**: push to your plugin-marketplace git
+  repo. The Wave 2 Script (Section 5) runs `marketplace update` on
+  every recurring cycle, so employee machines pick up new plugins
+  automatically at the next trigger — no MDM redeploy required. The
+  script's idempotent guard makes it safe to run hourly if you want a
+  tighter cadence.
+- **To remove a plugin**: remove it from the marketplace repo; the next
+  `marketplace update` run drops the symlink from employee machines.
+  Run `cowork-mdm plugin prune` on the machine (or extend the Wave 2
+  Script to include it) to clean up dangling entries. Users won't see a
+  warning; the plugin just disappears.
+- **To retire the whole deployment**: push a mobileconfig that only
+  contains `disableAutoUpdates: false` (if you want updates to resume)
+  and no other managed keys, plus a Script that calls `cowork-mdm
+  marketplace remove <url>`. Employees drop back to a vanilla Claude
+  Desktop on next launch.
+
+---
+
+**See also**:
+
+- [`specs/profile.md`](../specs/profile.md) — profile-format details and
+  the full `MobileConfigOpts` surface
+- [`specs/schema.md`](../specs/schema.md) — the 51-key schema with full
+  provenance
+- [`docs/research/skills-plugins-mdm.md`](research/skills-plugins-mdm.md) — why
+  skills and plugins must ship via Script payload, not mobileconfig

--- a/internal/profile/templates/enterprise-cn-full.yaml
+++ b/internal/profile/templates/enterprise-cn-full.yaml
@@ -1,0 +1,115 @@
+name: enterprise-cn-full
+description: |
+  One-shot enterprise onboarding scaffold for Chinese organizations deploying
+  Claude Desktop at fleet scale. Composes LLM + standalone MCP + egress +
+  auto-update + telemetry + sandbox policy into a single profile.
+
+  # THIS IS A SCAFFOLD, NOT A PRODUCTION PROFILE.
+  # Every REPLACE_* placeholder below MUST be filled in before deploying.
+  # `cowork-mdm profile validate` only checks schema correctness — it does
+  # NOT catch leftover placeholders. The intended usage is:
+  #
+  #   1. Copy this file to <your-org>/overrides.yaml
+  #   2. Fill every REPLACE_* placeholder with real values
+  #   3. cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
+  #   4. grep -q "REPLACE_" company.mobileconfig && echo "STOP: placeholders present"
+  #   5. cowork-mdm profile validate company.mobileconfig
+  #
+  # See docs/deployment-cn.md for the full deployment cookbook.
+  #
+  # --- LLM vendor table ---
+  # Pick one row below and paste its base URL + auth scheme into the
+  # inferenceGateway* values. If your org has a more specialized recipe,
+  # use one of the per-vendor templates instead (gateway-deepseek /
+  # gateway-glm / gateway-minimax).
+  #
+  #   Vendor    | inferenceGatewayBaseUrl                      | AuthScheme
+  #   ----------|----------------------------------------------|-----------
+  #   DeepSeek  | https://api.deepseek.com/anthropic           | x-api-key
+  #   Zhipu GLM | https://open.bigmodel.cn/api/anthropic       | bearer
+  #   MiniMax   | https://api.minimaxi.com/anthropic           | x-api-key
+  #
+  # --- Auto-update policy ---
+  # This template sets autoUpdaterEnforcementHours=168 (7 days). That's a
+  # forced-install window, NOT a hard block: Anthropic security patches
+  # still reach the fleet within a week. To hard-block updates entirely
+  # (stricter orgs; requires you to manually ship repackaged builds):
+  # replace `autoUpdaterEnforcementHours` with `disableAutoUpdates: true`.
+  #
+  # --- What this template does NOT deliver ---
+  # Skills, slash commands, hooks, and plugin-bundled MCPs do NOT ship
+  # inside the mobileconfig. They live under /Library/Application Support/
+  # Claude/org-plugins/ and are delivered via a separate Script payload
+  # invoking `cowork-mdm marketplace add <org-plugins-repo>`. See
+  # docs/deployment-cn.md Section 5 for the Script payload recipe, and
+  # docs/research/skills-plugins-mdm.md for why bootstrapUrl is NOT a
+  # substitute.
+  #
+  # --- Bootstrap config rotation (advanced) ---
+  # `bootstrapUrl` / `bootstrapEnabled` have no MDM scope in Claude
+  # Desktop's schema (both scope=null per #31 research), so this template
+  # does NOT set them. If your org needs a remote config-rotation endpoint
+  # for LLM / OTLP keys, set bootstrapUrl via the app's UI on each
+  # machine, or investigate per-user settings pushed through a different
+  # channel.
+
+values:
+  # ----- LLM provider (gateway mode) -----
+  inferenceProvider: gateway
+
+  # Skip the first-launch provider-picker screen. Safe once all the
+  # gateway-* values below are filled in.
+  disableDeploymentModeChooser: true
+
+  # REPLACE per the vendor table at the top of this file.
+  inferenceGatewayBaseUrl: https://REPLACE_WITH_VENDOR_BASE_URL
+  inferenceGatewayAuthScheme: bearer
+  inferenceGatewayApiKey: REPLACE_WITH_YOUR_API_KEY
+
+  # Pin a model list so users see the org-approved models only. Leave the
+  # JSON-array-as-string form (schema type: stringArray). Names below are
+  # generic placeholders — replace with your vendor's Anthropic-compatible
+  # model IDs (e.g. "deepseek-v4-pro" / "GLM-4.7" / "MiniMax-M2.7").
+  inferenceModels: >-
+    ["REPLACE_WITH_MODEL_ID_1","REPLACE_WITH_MODEL_ID_2"]
+
+  # ----- Standalone MCP servers -----
+  # JSON array of {name, url, transport, toolPolicy?} entries. Tokens in
+  # these URLs are readable by anyone with plist read access — rotate via
+  # MDM push rather than embedding long-lived secrets.
+  # Plugin-bundled MCPs (declared in a plugin's plugin.json) ship via
+  # org-plugins/, NOT this key.
+  managedMcpServers: >-
+    [{"name":"REPLACE_ME","url":"https://mcp.REPLACE_ME.internal/sse","transport":"sse","toolPolicy":{}}]
+
+  # ----- Egress allowlist -----
+  # Hostnames the Cowork sandbox may reach for tool calls and package
+  # installs. The inference provider host is always allowed automatically;
+  # add any internal MCP hosts + package registries you need. Supports
+  # *.example.com wildcards. Set to ["*"] to disable egress filtering
+  # entirely (not recommended).
+  coworkEgressAllowedHosts: >-
+    ["*.REPLACE_WITH_YOUR_INTERNAL_DOMAIN"]
+
+  # ----- Auto-update policy -----
+  # Forces pending updates to install after 7 days regardless of user
+  # activity. See header for trade-off vs disableAutoUpdates.
+  autoUpdaterEnforcementHours: 168
+
+  # ----- Telemetry -----
+  # Block product-usage analytics to Anthropic. Essential telemetry
+  # (crash reports, update checks) still flows unless you also set
+  # disableEssentialTelemetry.
+  disableNonessentialTelemetry: true
+
+  # ----- Sandbox / tool policy (optional) -----
+  # Uncomment and customize to restrict which built-in tools are
+  # available to employees. Tool names to disable are documented at:
+  # cowork-mdm schema show disabledBuiltinTools
+  # disabledBuiltinTools: >-
+  #   ["WebSearch"]
+
+  # Uncomment to lock the set of folders employees may attach as
+  # workspaces. Absolute paths; leading ~ expands per-user.
+  # allowedWorkspaceFolders: >-
+  #   ["~/work","/Volumes/ProjectShare"]

--- a/internal/profile/templates_test.go
+++ b/internal/profile/templates_test.go
@@ -10,6 +10,7 @@ func TestTemplateNames_IncludesAll(t *testing.T) {
 	names := TemplateNames()
 	want := []string{
 		"bedrock-basic",
+		"enterprise-cn-full",
 		"foundry",
 		"gateway",
 		"gateway-deepseek",
@@ -185,7 +186,7 @@ func TestLoadTemplate_NoLeakedKeysInGatewayTemplates(t *testing.T) {
 		regexp.MustCompile(`xai-[A-Za-z0-9]{20,}`),           // xAI
 		regexp.MustCompile(`gsk_[A-Za-z0-9]{20,}`),           // Groq
 	}
-	for _, name := range []string{"gateway-deepseek", "gateway-glm", "gateway-minimax"} {
+	for _, name := range []string{"gateway-deepseek", "gateway-glm", "gateway-minimax", "enterprise-cn-full"} {
 		t.Run(name, func(t *testing.T) {
 			raw, err := templateFS.ReadFile("templates/" + name + ".yaml")
 			if err != nil {
@@ -201,5 +202,36 @@ func TestLoadTemplate_NoLeakedKeysInGatewayTemplates(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLoadTemplate_EnterpriseCN(t *testing.T) {
+	p, err := LoadTemplate("enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("LoadTemplate enterprise-cn-full: %v", err)
+	}
+	if v, _ := p.Get("inferenceProvider"); v != "gateway" {
+		t.Errorf("inferenceProvider = %v, want gateway", v)
+	}
+	if v, _ := p.Get("autoUpdaterEnforcementHours"); v != int64(168) {
+		t.Errorf("autoUpdaterEnforcementHours = %v (%T), want int64(168)", v, v)
+	}
+	if v, _ := p.Get("disableNonessentialTelemetry"); v != true {
+		t.Errorf("disableNonessentialTelemetry = %v, want true", v)
+	}
+	if v, _ := p.Get("disableDeploymentModeChooser"); v != true {
+		t.Errorf("disableDeploymentModeChooser = %v, want true", v)
+	}
+	mcp, _ := p.Get("managedMcpServers")
+	if s, ok := mcp.(string); !ok || !strings.Contains(s, "REPLACE_ME") {
+		t.Errorf("managedMcpServers should contain REPLACE_ME placeholder, got %v", mcp)
+	}
+	egress, _ := p.Get("coworkEgressAllowedHosts")
+	arr, ok := egress.([]string)
+	if !ok {
+		t.Fatalf("coworkEgressAllowedHosts should be []string, got %T", egress)
+	}
+	if len(arr) == 0 || !strings.Contains(arr[0], "REPLACE_WITH_YOUR_INTERNAL_DOMAIN") {
+		t.Errorf("coworkEgressAllowedHosts should contain internal-domain placeholder, got %v", arr)
 	}
 }


### PR DESCRIPTION
## Summary

Ships the "open-box enterprise onboarding" story for Chinese orgs running Claude Desktop at fleet scale — combining the #29 per-vendor LLM templates, the #31 hybrid-delivery research, and a new one-shot scaffold + deployment cookbook.

- **`enterprise-cn-full.yaml` template** — composes gateway LLM + standalone MCP + egress allowlist + 7-day auto-update enforcement + telemetry opt-out + optional sandbox keys into a single scaffold. Header documents the vendor URL+auth matrix for DeepSeek / GLM / MiniMax, and explicitly notes that `bootstrapUrl` is NOT set (null MDM scope per #31 research).
- **`docs/deployment-cn.md`** — 8-section cookbook covering prerequisites, provider choice, generation (scaffold-vs-production warning + version-pinned YAML curl), validation (with placeholder-leak gate), distribution (two-wave mobileconfig + Script payload across Jamf / Intune / Kandji), verification (operational readiness checklist), failure modes, and updates.
- Section 5d carries the verbatim "skills via Script payload, not mobileconfig" block from #31's research verdict — evidence-backed messaging propagates to IT docs.

## Design decisions (for reviewer context)

- **Template is scaffold-only.** Every production value is a `REPLACE_*` placeholder. Cookbook explicitly flags that `profile validate` is schema-only and does NOT catch placeholders; adds a pre-distribution `grep -q "REPLACE_"` gate.
- **Auto-update default = 168-hour enforcement (7 days), not hard-block.** Documented trade-off in the template header. Security patches still reach the fleet; stricter orgs can override to `disableAutoUpdates: true`.
- **MDM API-key injection**: cookbook Section 3c documents two patterns (CI `envsubst` + per-machine `inferenceCredentialHelper`). Never bakes a real key into the template.
- **Script-payload binary resolution**: cookbook's Bash body resolves `cowork-mdm` across Intel + Apple Silicon brew layouts + `$COWORK_MDM_BIN` override + `command -v` fallback.
- **No new CLI subcommand.** `profile show-template <name>` to dump YAML source from embed FS would widen scope; cookbook documents `curl` from a version-pinned GitHub raw URL as the workaround. Follow-up issue candidate.

## Non-goals

- No changes to existing per-vendor templates (gateway-deepseek / gateway-glm / gateway-minimax).
- No new schema keys.
- No MDM-native plugin/skill delivery — #31 research established it's not possible; cookbook documents the hybrid path as the permanent answer.
- No golden file for `enterprise-cn-full` (scaffold is meant to be edited, not byte-exact locked; `TestLoadTemplate_AllTemplatesValidate` covers schema compliance).
- No Windows coverage — marked "not yet" in Section 5e, links to #9.

## Test plan

- [x] `go test ./internal/profile/...` green — includes new `TestLoadTemplate_EnterpriseCN` and extended `TestLoadTemplate_NoLeakedKeysInGatewayTemplates`.
- [x] `docs/execution/verify.sh task-03` PASSED — gofmt, vet, tidy, cross-build darwin+windows+linux, `-race` suite, plutil -lint on existing goldens.
- [x] `cowork-mdm profile templates` lists 9 entries with `enterprise-cn-full` alphabetically placed.
- [x] `profile new --template enterprise-cn-full --out /tmp/ecn.mobileconfig && profile validate` passes, 10 managed keys, placeholder-scan confirms scaffold-only semantics.
- [x] Sparring: plan APPROVE-with-must-fixes → addressed (scaffold-only warning + operational-readiness checklist) → code CONCERNS on 5 items → addressed (version-pinned YAML source, robust brew-path resolution, softened restart guidance, correct host-wide+per-user plist paths, Section 5/8 alignment) → re-review CONCERNS on 2 items → addressed (awk `{print $3}` for version, `--json` + Python parse) → **final APPROVE**.

Closes #30.

Follow-up issue candidates (not opening now; for discussion):
- `cowork-mdm profile show-template <name>` subcommand to dump embedded YAML to stdout or file (avoids the GitHub-raw curl dance in the cookbook).
- `cowork-mdm profile lint <file>` to flag leftover `REPLACE_*` placeholders (cookbook's grep-based gate productized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)