### PR TITLE
feat(profile): show-template + lint subcommands

### DIFF
--- a/cmd/cowork-mdm/cli/profile_cmd.go
+++ b/cmd/cowork-mdm/cli/profile_cmd.go
@@ -21,9 +21,11 @@ func newProfileCommand(stdout, stderr io.Writer) *cobra.Command {
 	}
 	cmd.AddCommand(newProfileNewCommand(stdout, stderr))
 	cmd.AddCommand(newProfileValidateCommand(stdout, stderr))
+	cmd.AddCommand(newProfileLintCommand(stdout, stderr))
 	cmd.AddCommand(newProfileApplyCommand(stdout, stderr))
 	cmd.AddCommand(newProfileStatusCommand(stdout, stderr))
 	cmd.AddCommand(newProfileTemplatesCommand(stdout, stderr))
+	cmd.AddCommand(newProfileShowTemplateCommand(stdout, stderr))
 	return cmd
 }
 
@@ -260,6 +262,88 @@ func newProfileTemplatesCommand(stdout, _ io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			for _, n := range profile.TemplateNames() {
 				fmt.Fprintln(stdout, n)
+			}
+			return nil
+		},
+	}
+}
+
+// --- profile show-template ---
+
+func newProfileShowTemplateCommand(stdout, _ io.Writer) *cobra.Command {
+	var outFile string
+	c := &cobra.Command{
+		Use:   "show-template NAME",
+		Short: "Dump the YAML source of a built-in template",
+		Long: `Dump the raw YAML source of a built-in profile template to stdout
+(or to a file via --out). Useful as a starting point for an enterprise
+overrides YAML, avoiding the need to curl from GitHub:
+
+  cowork-mdm profile show-template enterprise-cn-full --out overrides.yaml
+
+List available templates with: cowork-mdm profile templates`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			data, err := profile.ReadTemplateSource(args[0])
+			if err != nil {
+				return err
+			}
+			if outFile != "" {
+				if err := os.WriteFile(outFile, data, 0o644); err != nil {
+					return fmt.Errorf("write %s: %w", outFile, err)
+				}
+				return nil
+			}
+			_, err = stdout.Write(data)
+			return err
+		},
+	}
+	c.Flags().StringVar(&outFile, "out", "", "write to this path instead of stdout")
+	return c
+}
+
+// --- profile lint ---
+
+func newProfileLintCommand(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "lint FILE",
+		Short: "Flag REPLACE_* placeholder residuals in a generated profile",
+		Long: `Pre-distribution gate that scans every value in a generated
+mobileconfig / plist for leftover REPLACE_* placeholder tokens (e.g.
+REPLACE_WITH_YOUR_API_KEY, REPLACE_ME). Exits non-zero on any finding.
+
+Complements profile validate, which is schema-only and does NOT catch
+placeholders. Scope is narrow by design: only the REPLACE_<CAPS>
+convention is flagged; older template variable slots like ACCOUNT /
+PROFILE_ID in bedrock-basic are intentional and NOT flagged.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			p, _, err := decodeByDetection(data)
+			if err != nil {
+				return err
+			}
+			findings := profile.LintPlaceholders(p)
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				payload := map[string]any{
+					"file":     args[0],
+					"findings": findings,
+				}
+				enc := json.NewEncoder(stdout)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(payload); err != nil {
+					return err
+				}
+			} else {
+				fmt.Fprintf(stdout, "%s: %s", args[0], profile.FormatFindings(findings))
+			}
+			if len(findings) > 0 {
+				fmt.Fprintf(stderr, "%s: %d placeholder residual(s) present — do not distribute\n", args[0], len(findings))
+				return fmt.Errorf("placeholder residuals")
 			}
 			return nil
 		},

--- a/cmd/cowork-mdm/cli/profile_cmd_test.go
+++ b/cmd/cowork-mdm/cli/profile_cmd_test.go
@@ -136,6 +136,99 @@ func TestProfileValidate_FlagsGarbage(t *testing.T) {
 	}
 }
 
+func TestProfileShowTemplate_Stdout(t *testing.T) {
+	out, _, err := runCmd(t, "profile", "show-template", "enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("show-template: %v", err)
+	}
+	if !strings.HasPrefix(out, "name: enterprise-cn-full") {
+		t.Errorf("expected YAML to start with 'name: enterprise-cn-full', got %q", firstN(out, 60))
+	}
+	if !strings.Contains(out, "REPLACE_WITH_YOUR_API_KEY") {
+		t.Errorf("dumped YAML missing placeholder")
+	}
+}
+
+func TestProfileShowTemplate_OutFile(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "overrides.yaml")
+	_, _, err := runCmd(t, "profile", "show-template", "enterprise-cn-full", "--out", outPath)
+	if err != nil {
+		t.Fatalf("show-template --out: %v", err)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(data), "name: enterprise-cn-full") {
+		t.Errorf("file content wrong prefix: %q", firstN(string(data), 60))
+	}
+}
+
+func TestProfileShowTemplate_UnknownName(t *testing.T) {
+	_, _, err := runCmd(t, "profile", "show-template", "does-not-exist")
+	if err == nil {
+		t.Error("unknown template name should fail")
+	}
+	// Error should list available templates.
+	if !strings.Contains(err.Error(), "bedrock-basic") {
+		t.Errorf("error should list available templates, got: %v", err)
+	}
+}
+
+func TestProfileLint_DirtyProfileFails(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "dirty.mobileconfig")
+	if _, _, err := runCmd(t, "profile", "new", "--template", "enterprise-cn-full", "--out", p); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, "profile", "lint", p)
+	if err == nil {
+		t.Error("lint on dirty profile should fail")
+	}
+	if !strings.Contains(out, "REPLACE_WITH_YOUR_API_KEY") {
+		t.Errorf("lint output should name the placeholder, got: %q", firstN(out, 200))
+	}
+	if !strings.Contains(out, "placeholder") {
+		t.Errorf("lint output should mention placeholder, got: %q", firstN(out, 200))
+	}
+}
+
+func TestProfileLint_CleanProfilePasses(t *testing.T) {
+	// Build a profile from bedrock-basic which uses ACCOUNT / PROFILE_ID
+	// variable names (not the REPLACE_* convention) — lint must not flag.
+	dir := t.TempDir()
+	p := filepath.Join(dir, "clean.mobileconfig")
+	if _, _, err := runCmd(t, "profile", "new", "--template", "bedrock-basic", "--out", p); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, "profile", "lint", p)
+	if err != nil {
+		t.Errorf("lint on bedrock-basic should pass, got err=%v out=%s", err, out)
+	}
+	if !strings.Contains(out, "no placeholder") {
+		t.Errorf("lint output should confirm clean, got: %q", out)
+	}
+}
+
+func TestProfileLint_JSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "dirty.mobileconfig")
+	if _, _, err := runCmd(t, "profile", "new", "--template", "enterprise-cn-full", "--out", p); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, "profile", "lint", "--json", p)
+	if err == nil {
+		t.Error("lint on dirty profile should fail even with --json")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Errorf("--json output should start with {, got: %q", firstN(out, 80))
+	}
+	if !strings.Contains(out, `"findings"`) || !strings.Contains(out, `"match"`) {
+		t.Errorf("--json output missing findings structure: %q", firstN(out, 200))
+	}
+}
+
 func TestProfileApply_DryRun_NoSideEffects(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skipf("apply tests run only on darwin, got %s", runtime.GOOS)

--- a/docs/deployment-cn.md
+++ b/docs/deployment-cn.md
@@ -80,22 +80,15 @@ machines.
 ### 3b. Production path — copy, fill, `--from`
 
 The CLI's `profile new` emits `mobileconfig` or `plist` only (see
-`profile new --format`), not YAML. To get an editable YAML starting
-point, copy the template source from the installed CLI's release
-bundle — the version pinned to the CLI you have locally:
+`profile new --format`), not YAML. Use `profile show-template` to dump
+the YAML source of any built-in template as a starting point for your
+org's overrides file:
 
 ```bash
-# `cowork-mdm --version` prints e.g. `cowork-mdm version 0.3.0 (commit …, built …)`.
-# Extract the 3rd token as the semver tag.
-VERSION=$(cowork-mdm --version | awk '{print $3}')
-curl -L -o overrides.yaml \
-  "https://raw.githubusercontent.com/krislavten/cowork-mdm/v${VERSION}/internal/profile/templates/enterprise-cn-full.yaml"
-```
+# Dump the enterprise scaffold YAML to your private config repo
+# (NOT cowork-mdm's repo).
+cowork-mdm profile show-template enterprise-cn-full --out overrides.yaml
 
-Pinning to `v${VERSION}` (not `main`) keeps the YAML in lock-step with
-the CLI; `main` can diverge between releases and break `profile new`.
-
-```bash
 # 1. Replace every REPLACE_* placeholder in overrides.yaml with your
 #    real values: gateway base URL + auth scheme + API key, model IDs,
 #    MCP server list, egress allowlist, and any optional sandbox flags
@@ -106,9 +99,8 @@ cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
 ```
 
 `--template` and `--from` are mutually exclusive on a single
-invocation — pick one. (Follow-up issue for a `profile show-template
-<name>` dump-source subcommand tracked at time of writing — until
-it ships, `curl` is the supported path.)
+invocation — pick one. The YAML dumped by `show-template` always
+matches the CLI's own embedded copy, so there's no version drift.
 
 ### 3c. Inject the API key via MDM, not YAML
 
@@ -148,14 +140,25 @@ parseable. It does NOT check:
 - Whether MCP servers are reachable from employee machines.
 - Whether the profile is signed (required by some MDMs — see Section 5).
 
-Add a placeholder check to your pre-distribution pipeline:
+Run `profile lint` as a pre-distribution gate — it scans every value
+in the generated profile for leftover `REPLACE_*` placeholder tokens
+and exits non-zero on any finding:
 
 ```bash
-if grep -q "REPLACE_" company.mobileconfig; then
-  echo "ERROR: unfilled placeholders in profile — do not distribute"
-  exit 1
-fi
+cowork-mdm profile lint company.mobileconfig
+# Expected on a ready-to-ship profile:
+#   company.mobileconfig: no placeholder residuals
+# Expected on a scaffold with unfilled values (exit 1):
+#   company.mobileconfig: N placeholder(s) found — fill in before distributing:
+#     inferenceGatewayApiKey: REPLACE_WITH_YOUR_API_KEY
+#     ...
 ```
+
+`profile lint` is narrow by design — it only flags the reserved
+`REPLACE_*` convention used by the CN-focused templates. It is NOT a
+general config smell checker; older template variables like `ACCOUNT`
+or `PROFILE_ID` in `bedrock-basic` are intentional slots and NOT
+flagged.
 
 ## 5. Distribute via MDM
 
@@ -293,19 +296,20 @@ if not s.get("present"):
 print(f"OK: profile present at {s[\"targetPath\"]}")
 '
 
-# 2. No REPLACE_ placeholders leaked into production.
+# 2. No REPLACE_ placeholders leaked into the deployed plist.
 #    Claude Desktop's managed plist lives at one of these two paths
-#    (host-wide or per-user); check both.
+#    (host-wide or per-user); lint whichever is present. Preserves the
+#    failure signal so the readiness check as a whole exits non-zero if
+#    any plist is dirty.
 USER_PLIST="/Library/Managed Preferences/$USER/com.anthropic.claudefordesktop.plist"
 HOST_PLIST="/Library/Managed Preferences/com.anthropic.claudefordesktop.plist"
-LEAKED=0
+LINT_FAIL=0
 for f in "$USER_PLIST" "$HOST_PLIST"; do
-  if [ -f "$f" ] && /usr/bin/plutil -convert xml1 -o - "$f" 2>/dev/null | /usr/bin/grep -q "REPLACE_"; then
-    echo "FAIL: placeholder in $f"
-    LEAKED=1
+  if [ -f "$f" ] && ! cowork-mdm profile lint "$f"; then
+    LINT_FAIL=1
   fi
 done
-[ "$LEAKED" -eq 0 ] && echo "OK: no placeholders in deployed plist"
+[ "$LINT_FAIL" -ne 0 ] && { echo "FAIL: placeholder residuals in deployed plist" >&2; exit 1; }
 
 # 3. Plugins landed in org-plugins/.
 #    Expected: non-empty output. Empty = Script payload (5a/b/c) didn't
@@ -319,9 +323,6 @@ cowork-mdm doctor
 
 If all four return clean, the deployment is working. Roll to the rest
 of the fleet.
-
-`plutil -convert xml1 -o -` handles both XML and binary plist formats;
-`PlistBuddy -c Print` works too but omits raw values in some cases.
 
 ## 7. Common failure modes
 

--- a/internal/profile/lint.go
+++ b/internal/profile/lint.go
@@ -1,0 +1,86 @@
+package profile
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// PlaceholderFinding describes one leftover REPLACE_* placeholder
+// residual discovered in a Profile's values. Returned by
+// LintPlaceholders as a pre-distribution gate companion to Validate
+// (which is schema-only and does not catch placeholders).
+//
+// Only the key and the literal placeholder token are surfaced —
+// surrounding value text is intentionally omitted so that lint output
+// is safe to print to CI logs even when the value contains secrets.
+type PlaceholderFinding struct {
+	Key   string `json:"key"`
+	Match string `json:"match"`
+}
+
+// placeholderPattern matches the reserved REPLACE_<ALLCAPS_DIGITS_UNDERSCORES>
+// convention used by the CN-focused built-in templates
+// (REPLACE_WITH_YOUR_API_KEY, REPLACE_WITH_VENDOR_BASE_URL,
+// REPLACE_WITH_MODEL_ID_1, REPLACE_ME, REPLACE_WITH_YOUR_INTERNAL_DOMAIN).
+// Narrow by design: older templates (bedrock-basic, vertex) use
+// ACCOUNT / PROFILE_ID style variables that are documented as
+// intentional slots, not scaffolded placeholders, and are deliberately
+// NOT flagged.
+var placeholderPattern = regexp.MustCompile(`\bREPLACE_[A-Z0-9_]+\b`)
+
+// LintPlaceholders walks every value in p (including nested strings
+// inside stringArray / jsonString values) and returns every distinct
+// REPLACE_* match it finds, tagged with the top-level key that owns
+// the value. A clean Profile returns nil.
+func LintPlaceholders(p *Profile) []PlaceholderFinding {
+	var findings []PlaceholderFinding
+	for _, e := range p.Entries() {
+		for _, m := range scanValue(e.Value) {
+			findings = append(findings, PlaceholderFinding{Key: e.Key, Match: m})
+		}
+	}
+	return findings
+}
+
+// scanValue returns every REPLACE_* match found inside v, recursively
+// descending into string slices and map values. Non-string leaves
+// (int, bool, float) cannot contain placeholders and are ignored.
+func scanValue(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return placeholderPattern.FindAllString(t, -1)
+	case []string:
+		var out []string
+		for _, s := range t {
+			out = append(out, placeholderPattern.FindAllString(s, -1)...)
+		}
+		return out
+	case []any:
+		var out []string
+		for _, item := range t {
+			out = append(out, scanValue(item)...)
+		}
+		return out
+	case map[string]any:
+		var out []string
+		for _, item := range t {
+			out = append(out, scanValue(item)...)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// FormatFindings returns a human-readable summary of findings suitable
+// for printing to stdout from the CLI.
+func FormatFindings(findings []PlaceholderFinding) string {
+	if len(findings) == 0 {
+		return "no placeholder residuals"
+	}
+	out := fmt.Sprintf("%d placeholder(s) found — fill in before distributing:\n", len(findings))
+	for _, f := range findings {
+		out += fmt.Sprintf("  %s: %s\n", f.Key, f.Match)
+	}
+	return out
+}

--- a/internal/profile/lint_test.go
+++ b/internal/profile/lint_test.go
@@ -1,0 +1,145 @@
+package profile
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLintPlaceholders_EnterpriseCNDirty(t *testing.T) {
+	// enterprise-cn-full ships with REPLACE_* residuals by design —
+	// it's a scaffold, not a deployable profile. Lint must flag them.
+	p, err := LoadTemplate("enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	findings := LintPlaceholders(p)
+	if len(findings) == 0 {
+		t.Fatal("expected REPLACE_* findings in enterprise-cn-full scaffold, got none")
+	}
+	// Sanity: the critical LLM-auth key must be flagged.
+	var apiKeyFlagged bool
+	for _, f := range findings {
+		if f.Key == "inferenceGatewayApiKey" && f.Match == "REPLACE_WITH_YOUR_API_KEY" {
+			apiKeyFlagged = true
+		}
+	}
+	if !apiKeyFlagged {
+		t.Errorf("inferenceGatewayApiKey REPLACE_WITH_YOUR_API_KEY was not flagged; findings=%v", findings)
+	}
+}
+
+func TestLintPlaceholders_BedrockBasicClean(t *testing.T) {
+	// bedrock-basic uses documented variable slots (ACCOUNT,
+	// OPUS_PROFILE_ID, etc.) that are NOT the REPLACE_* convention.
+	// Lint must not flag them — that's the scope boundary.
+	p, err := LoadTemplate("bedrock-basic")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	findings := LintPlaceholders(p)
+	if len(findings) != 0 {
+		t.Errorf("bedrock-basic should have zero REPLACE_* findings (its variables use ACCOUNT / PROFILE_ID style), got %d: %v",
+			len(findings), findings)
+	}
+}
+
+func TestLintPlaceholders_MatchesWithDigits(t *testing.T) {
+	// Regression guard for the regex — \bREPLACE_[A-Z0-9_]+\b must
+	// match trailing digits (REPLACE_WITH_MODEL_ID_1 appears in
+	// enterprise-cn-full's inferenceModels list).
+	p, err := LoadTemplate("enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	findings := LintPlaceholders(p)
+	var sawDigit bool
+	for _, f := range findings {
+		if strings.HasSuffix(f.Match, "_1") || strings.HasSuffix(f.Match, "_2") {
+			sawDigit = true
+		}
+	}
+	if !sawDigit {
+		t.Errorf("expected at least one digit-suffixed match (REPLACE_WITH_MODEL_ID_1/_2); got %v", findings)
+	}
+}
+
+func TestLintPlaceholders_CleanAfterFilling(t *testing.T) {
+	// If a user fills in all placeholders, lint returns zero findings.
+	p, err := LoadTemplate("enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	for _, k := range []string{
+		"inferenceGatewayBaseUrl",
+		"inferenceGatewayApiKey",
+	} {
+		if err := p.Set(k, "https://actual-value.example.com"); err != nil {
+			t.Fatalf("Set %s: %v", k, err)
+		}
+	}
+	// Models + MCP + egress still contain placeholders, so findings
+	// should still be non-zero. But the two we filled above must not
+	// appear.
+	findings := LintPlaceholders(p)
+	for _, f := range findings {
+		if f.Key == "inferenceGatewayBaseUrl" || f.Key == "inferenceGatewayApiKey" {
+			t.Errorf("filled key %s still flagged: %+v", f.Key, f)
+		}
+	}
+}
+
+func TestLintPlaceholders_JsonStringNested(t *testing.T) {
+	// managedMcpServers is a jsonString — the REPLACE_ME match is
+	// inside a JSON-formatted string. Confirm lint sees it.
+	p, err := LoadTemplate("enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	findings := LintPlaceholders(p)
+	var sawMCP bool
+	for _, f := range findings {
+		if f.Key == "managedMcpServers" && strings.HasPrefix(f.Match, "REPLACE_") {
+			sawMCP = true
+		}
+	}
+	if !sawMCP {
+		t.Errorf("expected managedMcpServers to surface REPLACE_ME findings; got %v", findings)
+	}
+}
+
+func TestReadTemplateSource_EnterpriseCN(t *testing.T) {
+	b, err := ReadTemplateSource("enterprise-cn-full")
+	if err != nil {
+		t.Fatalf("ReadTemplateSource: %v", err)
+	}
+	if !strings.HasPrefix(string(b), "name: enterprise-cn-full") {
+		t.Errorf("expected YAML to start with 'name: enterprise-cn-full', got %q", string(b[:50]))
+	}
+	if !strings.Contains(string(b), "REPLACE_WITH_YOUR_API_KEY") {
+		t.Errorf("expected placeholder in source; got none")
+	}
+}
+
+func TestReadTemplateSource_Unknown(t *testing.T) {
+	_, err := ReadTemplateSource("does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for unknown template")
+	}
+	if !strings.Contains(err.Error(), "bedrock-basic") {
+		t.Errorf("error should list available templates, got: %s", err)
+	}
+}
+
+func TestFormatFindings(t *testing.T) {
+	empty := FormatFindings(nil)
+	if !strings.Contains(empty, "no placeholder") {
+		t.Errorf("empty findings format unclear: %q", empty)
+	}
+	two := FormatFindings([]PlaceholderFinding{
+		{Key: "inferenceGatewayApiKey", Match: "REPLACE_WITH_YOUR_API_KEY"},
+		{Key: "managedMcpServers", Match: "REPLACE_ME"},
+	})
+	if !strings.Contains(two, "2 placeholder") {
+		t.Errorf("expected count in output, got %q", two)
+	}
+}

--- a/internal/profile/templates.go
+++ b/internal/profile/templates.go
@@ -37,6 +37,21 @@ func LoadTemplate(name string) (*Profile, error) {
 	return instantiate(data)
 }
 
+// ReadTemplateSource returns the raw YAML bytes of the named built-in
+// template. Intended for the `profile show-template` subcommand to dump
+// the template so admins can copy + edit it as a starting point for
+// their own overrides YAML. An unknown name returns an error listing
+// the available templates.
+func ReadTemplateSource(name string) ([]byte, error) {
+	fname := path.Join("templates", name+".yaml")
+	b, err := fs.ReadFile(templateFS, fname)
+	if err != nil {
+		avail := strings.Join(TemplateNames(), ", ")
+		return nil, fmt.Errorf("template %q not found (available: %s)", name, avail)
+	}
+	return b, nil
+}
+
 // LoadTemplateFile is the same but from a caller-supplied filesystem path.
 // Used by `profile new --from path/to/my-profile.yaml` to keep enterprise-
 // specific configs (with ARNs, tokens, etc.) outside the binary.

--- a/internal/profile/templates/enterprise-cn-full.yaml
+++ b/internal/profile/templates/enterprise-cn-full.yaml
@@ -7,12 +7,13 @@ description: |
   # THIS IS A SCAFFOLD, NOT A PRODUCTION PROFILE.
   # Every REPLACE_* placeholder below MUST be filled in before deploying.
   # `cowork-mdm profile validate` only checks schema correctness — it does
-  # NOT catch leftover placeholders. The intended usage is:
+  # NOT catch leftover placeholders. Use `profile lint` for that. Intended
+  # usage:
   #
-  #   1. Copy this file to <your-org>/overrides.yaml
+  #   1. cowork-mdm profile show-template enterprise-cn-full --out overrides.yaml
   #   2. Fill every REPLACE_* placeholder with real values
   #   3. cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
-  #   4. grep -q "REPLACE_" company.mobileconfig && echo "STOP: placeholders present"
+  #   4. cowork-mdm profile lint company.mobileconfig   (must exit 0)
   #   5. cowork-mdm profile validate company.mobileconfig
   #
   # See docs/deployment-cn.md for the full deployment cookbook.


### PR DESCRIPTION
## Summary

Productizes two cookbook papercuts left over from #30:

1. **`cowork-mdm profile show-template NAME [--out FILE]`** — dumps the embedded YAML source of a built-in template. Replaces the cookbook's `curl -L https://…/v${VERSION}/…` + `awk '{print $3}'` version-pin dance. The dumped YAML always matches the CLI's own embed, so drift is impossible.

2. **`cowork-mdm profile lint FILE [--json]`** — scans a generated mobileconfig/plist for leftover `REPLACE_*` placeholder tokens, exits non-zero on any finding. Complements `profile validate` (schema-only, doesn't catch placeholders). Replaces the cookbook's shell `grep -q "REPLACE_"` one-liner.

## Scope boundaries (narrow by design)

- **Lint regex**: `\bREPLACE_[A-Z0-9_]+\b` — flags only the reserved `REPLACE_*` convention used by CN-focused templates. `bedrock-basic` / `vertex` style `ACCOUNT` / `PROFILE_ID` variables are intentional slots and NOT flagged. Tested via `TestLintPlaceholders_BedrockBasicClean`.
- **Findings carry only `{Key, Match}`** — no value content. Safe for CI logs even when values contain secrets.
- **show-template overwrites `--out` silently** — consistent with `profile new --out`.

## What's new

**Library** (`internal/profile/`):
- `ReadTemplateSource(name) ([]byte, error)` in `templates.go` — exports the embed.FS read for the CLI layer.
- `PlaceholderFinding` + `LintPlaceholders(*Profile) []PlaceholderFinding` + `FormatFindings([]PlaceholderFinding) string` in new `lint.go`. Recursive scan over `string` / `[]string` / `[]any` / `map[string]any`.

**CLI** (`cmd/cowork-mdm/cli/profile_cmd.go`):
- `newProfileShowTemplateCommand` — cobra subcommand, `ExactArgs(1)`, `--out` flag.
- `newProfileLintCommand` — cobra subcommand, `ExactArgs(1)`, `--json` flag, returns error on findings (cobra propagates to exit 1).

**Tests**: 14 total.
- `lint_test.go` (8): `*_EnterpriseCNDirty`, `*_BedrockBasicClean` (scope guard), `*_MatchesWithDigits` (regex regression for `REPLACE_WITH_MODEL_ID_1/_2`), `*_CleanAfterFilling`, `*_JsonStringNested`, `ReadTemplateSource_*`, `FormatFindings`.
- `profile_cmd_test.go` (6): `ShowTemplate_Stdout` / `_OutFile` / `_UnknownName` + `Lint_DirtyProfileFails` / `_CleanProfilePasses` / `_JSON`.

**Docs**:
- `docs/deployment-cn.md` Section 3b (`show-template` replaces curl), Section 4 (lint replaces grep shell), Section 6 Step 2 (lint with failure-signal-preserving `LINT_FAIL` accumulator).
- `internal/profile/templates/enterprise-cn-full.yaml` header 5-step flow updated to use new commands.

## Sparring trail

- **Plan CONCERNS**: regex missed digits (`REPLACE_WITH_MODEL_ID_1` in the template) — fixed to `\bREPLACE_[A-Z0-9_]+\b`.
- **Code CONCERNS**: `|| echo` in Section 6 swallowed lint's non-zero exit — fixed with `LINT_FAIL=1` accumulator + final `exit 1`.
- **Re-review APPROVE**.

## Test plan

- [x] `go test ./...` green — 14 new tests, 0 regressions.
- [x] `docs/execution/verify.sh task-03` PASSED — gofmt, vet, tidy, cross-build darwin+windows+linux, `-race` suite, plutil -lint on goldens.
- [x] `cowork-mdm profile show-template enterprise-cn-full` → 115 lines YAML.
- [x] `cowork-mdm profile show-template does-not-exist` → error lists 9 templates.
- [x] `cowork-mdm profile lint /tmp/dirty.mobileconfig` → 7 findings, exit 1.
- [x] `cowork-mdm profile lint --json /tmp/dirty.mobileconfig` → valid JSON on stdout, diagnostics on stderr, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)