### PR TITLE
docs(readme): realign to enterprise-deployment narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # cowork-mdm
 
-> Deploy Claude Desktop across enterprise fleets — MDM profiles for Bedrock / Vertex / Foundry / Chinese LLM gateways, org-plugin distribution, per-host diagnostics.
+**English** · [中文](README.zh.md)
+
+> Deploy Claude Desktop across enterprise fleets — MDM profiles for Bedrock / Vertex / Foundry / third-party and self-hosted LLM gateways, org-plugin distribution, per-host diagnostics.
 
 **Status**: **v0.3 — CLI + Claude Code plugin.** The CLI generates MDM profiles (`.mobileconfig` / plist), manages the org plugin marketplace, and diagnoses broken hosts. A Claude Code plugin layer (skills + slash commands) makes the CLI self-driving inside an agent. Both ship together.
 
@@ -8,7 +10,7 @@
 
 ## Why cowork-mdm
 
-**Claude Desktop supports third-party Anthropic-compatible LLM providers.** For Chinese enterprises, that now includes **DeepSeek / GLM / MiniMax** out of the box — the first time Claude Desktop workflows are deployable in regions where `api.anthropic.com` isn't the answer. For global orgs, the same mechanism covers AWS Bedrock, Google Vertex, Azure AI Foundry, and any self-hosted OpenAI-compatible gateway.
+**Claude Desktop supports third-party Anthropic-compatible LLM providers.** Enterprises pick providers based on cost, data residency, compliance, and model preference — and Claude Desktop accepts all of them through `inferenceProvider=gateway` or dedicated Bedrock / Vertex / Foundry keys. That covers hyperscaler routes (AWS Bedrock, Google Vertex, Azure AI Foundry), self-hosted vLLM / SGLang behind an Anthropic-compatible shim, and third-party gateway services (DeepSeek, Zhipu GLM, MiniMax, Mistral's API, and similar). `cowork-mdm` lets IT deploy whichever choice at fleet scale.
 
 **But the deployment config is non-trivial.** Gateway URL + auth scheme + managed MCP servers + egress allowlist + auto-update policy + telemetry policy + sandbox constraints — Claude Desktop reads 51 managed-preferences keys, of which Anthropic's public enterprise documentation covers only 8. End users can't self-serve this; IT has to push it at fleet scale via Jamf / Microsoft Intune / Kandji. `cowork-mdm` surfaces the full schema (extracted from the app's embedded zod schema, currently pinned to Claude.app 1.5354.0), generates correct MDM profiles, and runs per-host diagnostics so IT doesn't have to reverse-engineer the Electron bundle.
 
@@ -19,7 +21,7 @@
 ```bash
 brew install krislavten/tap/cowork-mdm
 
-# Happy path for a CN enterprise onboarding:
+# Happy path for an enterprise gateway deployment:
 cowork-mdm profile show-template enterprise-cn-full --out overrides.yaml
 $EDITOR overrides.yaml                           # fill REPLACE_* placeholders
 cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
@@ -30,11 +32,11 @@ cowork-mdm profile validate company.mobileconfig
 
 ## Enterprise deployment cookbook
 
-**See [docs/deployment-cn.md](docs/deployment-cn.md)** — 8-section end-to-end recipe:
+**See [docs/deployment-cn.md](docs/deployment-cn.md)** — 8-section end-to-end recipe for gateway-mode deployments:
 
-1. Prerequisites 2. Pick an LLM provider (DeepSeek / GLM / MiniMax) 3. Generate the profile 4. Validate & lint 5. Distribute via Jamf / Intune / Kandji (with Script payload for plugins) 6. Verify on an employee machine 7. Common failure modes 8. Updating later.
+1. Prerequisites 2. Pick an LLM provider 3. Generate the profile 4. Validate & lint 5. Distribute via Jamf / Intune / Kandji (with Script payload for plugins) 6. Verify on an employee machine 7. Common failure modes 8. Updating later.
 
-For global deployments using Bedrock / Vertex / Foundry, the same CLI surface applies — start from [`specs/profile.md`](specs/profile.md) and use the `bedrock-basic` / `vertex` / `foundry` built-in templates.
+For Bedrock / Vertex / Foundry deployments the same CLI surface applies — start from [`specs/profile.md`](specs/profile.md) and use the `bedrock-basic` / `vertex` / `foundry` built-in templates.
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -1,115 +1,88 @@
 # cowork-mdm
 
-> CLI toolkit for deploying Claude Desktop in the enterprise: MDM config profiles, plugin marketplace management, and per-host diagnostics.
+> Deploy Claude Desktop across enterprise fleets — MDM profiles for Bedrock / Vertex / Foundry / Chinese LLM gateways, org-plugin distribution, per-host diagnostics.
 
-**Status**: **v0.3 — CLI + Claude Code plugin.** The CLI delivers profile generation, plugin marketplace management, and diagnostics. v0.3 adds a Claude Code plugin layer (skills + slash commands) that teaches an agent how to drive the CLI on the user's behalf. Plugin `v0.3.0` wraps CLI `v0.3.0`; both ship together.
+**Status**: **v0.3 — CLI + Claude Code plugin.** The CLI generates MDM profiles (`.mobileconfig` / plist), manages the org plugin marketplace, and diagnoses broken hosts. A Claude Code plugin layer (skills + slash commands) makes the CLI self-driving inside an agent. Both ship together.
 
 **Not affiliated with Anthropic.** This project is an independent effort based on reverse-engineering the public Claude Desktop application.
 
-## Why
+## Why cowork-mdm
 
-Anthropic's public enterprise documentation covers **8 of the 51** MDM keys that `Claude.app` actually reads. The remaining keys — `inferenceProvider`, `inferenceBedrockRegion`, `managedMcpServers`, `coworkEgressAllowedHosts`, `bootstrapUrl`, and more — are defined in the app's embedded zod schema (`FJ = me({...})`) but undocumented publicly.
+**Claude Desktop supports third-party Anthropic-compatible LLM providers.** For Chinese enterprises, that now includes **DeepSeek / GLM / MiniMax** out of the box — the first time Claude Desktop workflows are deployable in regions where `api.anthropic.com` isn't the answer. For global orgs, the same mechanism covers AWS Bedrock, Google Vertex, Azure AI Foundry, and any self-hosted OpenAI-compatible gateway.
 
-Deploying Claude Desktop in 3rd-party inference mode (Bedrock, Vertex, LLM gateway, Azure Foundry) relies heavily on these undocumented keys. `cowork-mdm` surfaces the schema, generates correct config profiles (`.mobileconfig` / `.reg` / Jamf / Intune formats), manages the org plugin marketplace, and runs per-host diagnostics — so IT admins don't have to reverse-engineer the Electron bundle themselves.
+**But the deployment config is non-trivial.** Gateway URL + auth scheme + managed MCP servers + egress allowlist + auto-update policy + telemetry policy + sandbox constraints — Claude Desktop reads 51 managed-preferences keys, of which Anthropic's public enterprise documentation covers only 8. End users can't self-serve this; IT has to push it at fleet scale via Jamf / Microsoft Intune / Kandji. `cowork-mdm` surfaces the full schema (extracted from the app's embedded zod schema, currently pinned to Claude.app 1.5354.0), generates correct MDM profiles, and runs per-host diagnostics so IT doesn't have to reverse-engineer the Electron bundle.
+
+**MDM delivers the config layer; a Script payload delivers the rest.** LLM credentials, MCP servers, egress, telemetry, and sandbox policy all ride in the mobileconfig. Company skills, slash commands, and plugin-bundled MCPs live under `/Library/Application Support/Claude/org-plugins/` and are delivered via a companion Script payload that runs `cowork-mdm marketplace add`. This hybrid is necessary by design — the reverse-engineered evidence is documented in [docs/research/skills-plugins-mdm.md](docs/research/skills-plugins-mdm.md).
 
 ## Quick start
 
 ```bash
-# macOS (Homebrew)
 brew install krislavten/tap/cowork-mdm
 
-# Or download a binary from the Releases page:
-# https://github.com/krislavten/cowork-mdm/releases
+# Happy path for a CN enterprise onboarding:
+cowork-mdm profile show-template enterprise-cn-full --out overrides.yaml
+$EDITOR overrides.yaml                           # fill REPLACE_* placeholders
+cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
+cowork-mdm profile lint company.mobileconfig    # pre-distribution gate
+cowork-mdm profile validate company.mobileconfig
+# Then push company.mobileconfig via your MDM — full recipe in the cookbook.
 ```
 
-## Commands
+## Enterprise deployment cookbook
 
+**See [docs/deployment-cn.md](docs/deployment-cn.md)** — 8-section end-to-end recipe:
+
+1. Prerequisites 2. Pick an LLM provider (DeepSeek / GLM / MiniMax) 3. Generate the profile 4. Validate & lint 5. Distribute via Jamf / Intune / Kandji (with Script payload for plugins) 6. Verify on an employee machine 7. Common failure modes 8. Updating later.
+
+For global deployments using Bedrock / Vertex / Foundry, the same CLI surface applies — start from [`specs/profile.md`](specs/profile.md) and use the `bedrock-basic` / `vertex` / `foundry` built-in templates.
+
+## Command reference
+
+Grouped by intent. Every subcommand accepts `--json` for machine-readable output.
+
+**Author a profile**
 ```bash
-# Schema + path reference
-cowork-mdm schema list                     # all 51 keys (name, type, scope, appMin)
-cowork-mdm schema show inferenceProvider   # details: description, example, allowed values
-cowork-mdm paths show                      # host paths cowork-mdm reads
-cowork-mdm paths show --os windows         # simulate a different platform
+cowork-mdm profile templates                           # list built-in templates
+cowork-mdm profile show-template NAME [--out FILE]     # dump a template's YAML source
+cowork-mdm profile new --from overrides.yaml --out out.mobileconfig
+cowork-mdm profile lint out.mobileconfig               # flag REPLACE_* placeholders
+cowork-mdm profile validate out.mobileconfig           # schema check
+```
+`--template` and `--from` are mutually exclusive. `lint` complements `validate`: validate is schema-only; lint catches unfilled scaffold placeholders.
 
-# Profile authoring (YAML → .mobileconfig / plist)
-# --template and --from are mutually exclusive; pick one:
-cowork-mdm profile templates
-cowork-mdm profile new --template bedrock-basic --out my.mobileconfig  # built-in verbatim
-cowork-mdm profile new --from overrides.yaml --out my.mobileconfig     # your own YAML
-cowork-mdm profile validate my.mobileconfig
-cowork-mdm profile status                  # what's currently active on this host
+**Inspect the schema**
+```bash
+cowork-mdm schema list                          # all 51 keys (name, type, scope, appMin)
+cowork-mdm schema show inferenceProvider        # description, example, allowed values
+cowork-mdm paths show [--os darwin|windows]     # paths cowork-mdm reads on each platform
+```
 
-# Marketplace + plugin management (macOS)
-cowork-mdm marketplace add https://github.com/anthropics/claude-plugins-official
+**Apply & verify on a host**
+```bash
+cowork-mdm profile apply company.mobileconfig --dry-run    # preview, no writes
+cowork-mdm profile status                                   # what's currently active
+cowork-mdm doctor [--fix]                                   # diagnose broken installs
+```
+
+**Manage org plugins (macOS)**
+```bash
+cowork-mdm marketplace add https://github.com/<org>/claude-org-plugins
 cowork-mdm marketplace update
 cowork-mdm plugin list
 cowork-mdm plugin prune
-
-# Diagnostics
-cowork-mdm doctor
-cowork-mdm doctor --fix
 ```
 
-Every subcommand accepts `--json` for machine-readable output. Spec and
-task breakdown: [`specs/`](specs/) + [`docs/execution/TASKS.md`](docs/execution/TASKS.md).
+Spec and task breakdown: [`specs/`](specs/) + [`docs/execution/TASKS.md`](docs/execution/TASKS.md).
 
-## Enterprise deployment
+## Claude Code plugin
 
-**Chinese LLM providers (DeepSeek / GLM / MiniMax) + MDM fleet rollout**:
-see [docs/deployment-cn.md](docs/deployment-cn.md) for the full cookbook
-covering Jamf / Intune / Kandji distribution, the `enterprise-cn-full`
-template, and the Script-payload pattern for shipping company plugins
-alongside the mobileconfig.
+v0.3 also ships a Claude Code plugin layer so an agent can drive the CLI on the user's behalf — 5 skills + 4 slash commands covering profile authoring, deployment, plugin management, and diagnostics. Ships **no new logic**; requires the CLI on `PATH`. Full surface documented in [`specs/claude-plugin.md`](specs/claude-plugin.md).
 
-## Use as a Claude Code plugin
-
-v0.3 adds a Claude Code plugin layer: five skills + four slash commands
-that teach an agent how to drive the `cowork-mdm` CLI safely on a user's
-behalf. The plugin ships **no new logic** — it's a documentation bundle
-that makes the CLI self-driving inside Claude Code.
-
-### Install (in Claude Code)
-
+Install in Claude Code:
 ```
 /plugin marketplace add https://github.com/krislavten/cowork-mdm
 /plugin install cowork-mdm@cowork-mdm
 ```
-
-The CLI itself must still be installed via Homebrew (see Quick start) —
-the plugin reports "CLI missing, install via brew" and stops if `cowork-mdm`
-isn't on `PATH`.
-
-### What the agent gets
-
-**Skills** — loaded automatically when the user's request matches:
-
-| Skill | Loaded when the user asks about … |
-| --- | --- |
-| `cowork-mdm` | generic Claude Desktop MDM questions (routes to a specialist) |
-| `mdm-profile-authoring` | writing / editing a profile, looking up schema keys, Bedrock / Vertex / Azure / gateway recipes |
-| `mdm-profile-deploy` | pushing a profile via Jamf / Intune / Kandji, verifying status, why a config isn't taking effect |
-| `mdm-plugins` | installing or updating `org-plugins/` marketplaces, dangling symlinks |
-| `mdm-doctor` | troubleshooting a broken Claude Desktop install |
-
-**Slash commands** — executable playbooks:
-
-| Command | What it does |
-| --- | --- |
-| `/cowork-mdm:new-profile` | interactive profile generator (pick provider → collect values → generate → validate) |
-| `/cowork-mdm:deploy PATH` | validate + dry-run preview, diff against current host, hand off for MDM push |
-| `/cowork-mdm:doctor` | run `cowork-mdm doctor --json`, interpret findings, suggest specific fixes |
-| `/cowork-mdm:refresh-plugins` | `marketplace update` + `plugin prune` dry-run |
-
-### Safety invariants the plugin enforces
-
-- **Never `sudo`.** Writes to `/Library/Managed Preferences/` and
-  `/Library/Application Support/Claude/` always remain the user's explicit
-  action.
-- **Production deploys go through an MDM channel.** Direct plist writes
-  are clobbered by `managedappconfigd` on the next sync; the plugin
-  refuses that path.
-- **Enterprise secrets stay in the user's overrides YAML**, never in the
-  repo's built-in templates.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,111 @@
+# cowork-mdm
+
+[English](README.md) · **中文**
+
+> 面向企业集群的 Claude Desktop 下发工具链 —— 覆盖 Bedrock / Vertex / Foundry / 第三方及自托管 LLM 网关的 MDM 配置下发、组织插件分发、主机诊断。
+
+**状态**：**v0.3 —— CLI + Claude Code 插件层。** CLI 负责生成 MDM 配置 (`.mobileconfig` / plist)、管理组织插件市场、诊断异常主机。Claude Code 插件层（技能 + 斜杠命令）让 Agent 可以代你驱动 CLI。两者同步发版。
+
+**与 Anthropic 无官方关联。** 本项目基于对公开 Claude Desktop 应用的逆向工程，独立开发维护。
+
+## 为什么需要 cowork-mdm
+
+**Claude Desktop 支持第三方 Anthropic-兼容 LLM provider。** 企业会基于成本、数据驻留、合规、模型偏好等因素选择不同 provider —— Claude Desktop 通过 `inferenceProvider=gateway` 或专用的 Bedrock / Vertex / Foundry 键全都接得上。这涵盖了云厂商路径 (AWS Bedrock / Google Vertex / Azure AI Foundry)、自托管的 vLLM / SGLang 配合 Anthropic-兼容适配层，以及各类第三方网关服务 (DeepSeek / Zhipu GLM / MiniMax / Mistral API 等)。`cowork-mdm` 让 IT 把任意选择下发到整个集群。
+
+**但部署配置并不简单。** 网关 URL + 鉴权方式 + 托管 MCP 服务 + 出口白名单 + 自动更新策略 + 遥测策略 + 沙箱约束 —— Claude Desktop 要读 51 个 managed-preferences 键，其中 Anthropic 公开企业文档只覆盖 8 个。终端用户没办法自助，IT 必须通过 Jamf / Microsoft Intune / Kandji 按集群规模批量下发。`cowork-mdm` 把完整 schema（从应用内嵌 zod 定义提取，当前锁定在 Claude.app 1.5354.0）暴露出来，生成正确的 MDM 配置，提供主机级诊断，让 IT 不需要自己拆 Electron bundle。
+
+**MDM 负责配置层，Script payload 负责其余部分。** LLM 凭据、MCP 服务、出口策略、遥测、沙箱策略全都进 mobileconfig。公司技能、斜杠命令、插件内置的 MCP 放在 `/Library/Application Support/Claude/org-plugins/`，需要配套的 Script payload 调用 `cowork-mdm marketplace add` 来下发。这种混合下发是必须的 —— 反向工程证据见 [docs/research/skills-plugins-mdm.md](docs/research/skills-plugins-mdm.md)。
+
+## 快速开始
+
+```bash
+brew install krislavten/tap/cowork-mdm
+
+# 企业 gateway 部署的标准路径：
+cowork-mdm profile show-template enterprise-cn-full --out overrides.yaml
+$EDITOR overrides.yaml                           # 填写 REPLACE_* 占位符
+cowork-mdm profile new --from overrides.yaml --out company.mobileconfig
+cowork-mdm profile lint company.mobileconfig    # 下发前占位符体检
+cowork-mdm profile validate company.mobileconfig
+# 接下来通过你公司的 MDM 下发 company.mobileconfig —— 完整步骤见 cookbook。
+```
+
+## 企业部署手册
+
+**完整手册见 [docs/deployment-cn.md](docs/deployment-cn.md)** —— 八节 gateway 模式端到端流程：
+
+1. 前置准备 2. 选择 LLM provider 3. 生成配置 4. 校验 + lint 5. 通过 Jamf / Intune / Kandji 下发（含插件的 Script payload） 6. 员工机验证 7. 常见失败场景 8. 后续更新。
+
+使用 Bedrock / Vertex / Foundry 的部署同样适用，起点是 [`specs/profile.md`](specs/profile.md) 和内置的 `bedrock-basic` / `vertex` / `foundry` 模板。
+
+## 命令参考
+
+按使用意图分组。所有子命令都支持 `--json` 输出机器可读结果。
+
+**编写配置**
+```bash
+cowork-mdm profile templates                           # 列出内置模板
+cowork-mdm profile show-template NAME [--out FILE]     # 导出模板 YAML 源
+cowork-mdm profile new --from overrides.yaml --out out.mobileconfig
+cowork-mdm profile lint out.mobileconfig               # 标记 REPLACE_* 残留占位符
+cowork-mdm profile validate out.mobileconfig           # schema 校验
+```
+`--template` 和 `--from` 互斥。`lint` 和 `validate` 互补：`validate` 只做 schema 检查，`lint` 抓脚手架里没填完的占位符。
+
+**查询 schema**
+```bash
+cowork-mdm schema list                          # 全部 51 个键 (名称、类型、作用域、appMin)
+cowork-mdm schema show inferenceProvider        # 描述、示例值、允许值
+cowork-mdm paths show [--os darwin|windows]     # 各平台的读取路径
+```
+
+**应用 + 验证**
+```bash
+cowork-mdm profile apply company.mobileconfig --dry-run    # 预览，不写入
+cowork-mdm profile status                                   # 当前主机的活跃配置
+cowork-mdm doctor [--fix]                                   # 诊断异常安装
+```
+
+**管理组织插件 (macOS)**
+```bash
+cowork-mdm marketplace add https://github.com/<org>/claude-org-plugins
+cowork-mdm marketplace update
+cowork-mdm plugin list
+cowork-mdm plugin prune
+```
+
+规格文档与任务拆解：[`specs/`](specs/) + [`docs/execution/TASKS.md`](docs/execution/TASKS.md)。
+
+## Claude Code 插件
+
+v0.3 同时发布了 Claude Code 插件层，让 Agent 能代你驱动 CLI —— 5 个技能 + 4 个斜杠命令，覆盖配置编写、下发、插件管理、诊断。**不引入任何新逻辑**，依赖 `PATH` 上已有的 CLI。完整接口见 [`specs/claude-plugin.md`](specs/claude-plugin.md)。
+
+在 Claude Code 中安装：
+```
+/plugin marketplace add https://github.com/krislavten/cowork-mdm
+/plugin install cowork-mdm@cowork-mdm
+```
+
+## 贡献
+
+开发规范见 [AGENTS.md](AGENTS.md)。欢迎 Issue 和 PR。
+
+## 维护者说明
+
+### 发版
+
+发版由 tag 触发。推送一个 `v*` tag，`.github/workflows/release.yml` 会调用 GoReleaser。
+
+发版任务会同时推到两个地方：
+1. **GitHub Releases** 本仓库 —— 使用默认的 `GITHUB_TOKEN`。
+2. **Homebrew tap** 位于 `krislavten/homebrew-tap` —— 需要本仓库配置 `HOMEBREW_TAP_GITHUB_TOKEN` secret，必须是 PAT（经典或 fine-grained），对 `krislavten/homebrew-tap` 具有 **contents:write** 权限。没配置时 brew formula 推送会失败，但其余步骤（GitHub Release + 二进制 + 校验和）仍然成功。
+
+一次性配置 secret：
+```bash
+gh secret set HOMEBREW_TAP_GITHUB_TOKEN --repo krislavten/cowork-mdm
+# 提示时粘贴 PAT
+```
+
+## License
+
+MIT —— 见 [LICENSE](LICENSE)。

--- a/docs/deployment-cn.md
+++ b/docs/deployment-cn.md
@@ -1,9 +1,16 @@
-# Claude Desktop enterprise deployment — Chinese LLM providers
+# Claude Desktop enterprise deployment — gateway-mode cookbook
 
 End-to-end recipe for taking Claude Desktop from "fresh Mac" to "employee
-logged in, talking to the company-approved Chinese LLM with company MCP
-servers and company skills/commands". Target audience: enterprise IT /
-ops running Jamf Pro, Microsoft Intune, or Kandji for macOS fleets.
+logged in, talking to the company-approved LLM provider with company MCP
+servers and company skills / slash commands". Target audience: enterprise
+IT / ops running Jamf Pro, Microsoft Intune, or Kandji for macOS fleets.
+
+Covers the `inferenceProvider=gateway` path: third-party Anthropic-
+compatible services (DeepSeek, Zhipu GLM, MiniMax, Mistral, …) and
+self-hosted vLLM / SGLang behind an Anthropic-compatible shim. For
+Bedrock / Vertex / Foundry deployments use the `bedrock-basic` /
+`vertex` / `foundry` built-in templates instead; the distribution
+mechanics (Sections 5–8) are identical.
 
 Scope: macOS. Windows is not yet supported end-to-end (tracked in
 [issue #9](https://github.com/krislavten/cowork-mdm/issues/9)).
@@ -20,8 +27,9 @@ Scope: macOS. Windows is not yet supported end-to-end (tracked in
 
 Before starting, gather:
 
-- **Vendor API key.** Created on the vendor's platform console (DeepSeek,
-  Zhipu GLM, or MiniMax). You'll inject this via your MDM's secret-variable
+- **Vendor API key.** Created on the provider's platform console (e.g.
+  DeepSeek, Zhipu GLM, MiniMax, Mistral, or your self-hosted gateway's
+  admin console). You'll inject this via your MDM's secret-variable
   mechanism, not by hand-pasting into a YAML file.
 - **Admin access to your MDM system** (Jamf Pro / Intune / Kandji) —
   specifically the permission to push a Custom Settings Payload + a
@@ -44,9 +52,10 @@ Before starting, gather:
 
 ## 2. Pick your LLM provider
 
-Pre-baked templates cover the three domestic providers with Anthropic-
+Pre-baked templates cover several gateway providers with Anthropic-
 compatible endpoints. Pick one and note its values — you'll use them in
-Section 3.
+Section 3. If your provider isn't listed, start from the generic
+`gateway` template and supply the base URL + auth scheme yourself.
 
 | Vendor      | Template (if using one)    | `inferenceGatewayBaseUrl`                 | `inferenceGatewayAuthScheme` |
 | ----------- | -------------------------- | ----------------------------------------- | ---------------------------- |
@@ -155,7 +164,7 @@ cowork-mdm profile lint company.mobileconfig
 ```
 
 `profile lint` is narrow by design — it only flags the reserved
-`REPLACE_*` convention used by the CN-focused templates. It is NOT a
+`REPLACE_*` convention used by the gateway-mode enterprise templates. It is NOT a
 general config smell checker; older template variables like `ACCOUNT`
 or `PROFILE_ID` in `bedrock-basic` are intentional slots and NOT
 flagged.


### PR DESCRIPTION
## Summary

Realigns the project's narrative surfaces around **provider-neutral enterprise deployment** instead of the v0.1 reverse-engineering story. After #29 (gateway templates) + #30 (cookbook) + #31 (MDM capability research) + #35 (show-template + lint), the product has a complete narrative loop; the README should reflect "deploy Claude Desktop to enterprise fleets with whichever LLM route fits your org" — not "we reverse-engineered 8 → 51 keys".

## What changes

**Tagline** (provider-neutral):
> Deploy Claude Desktop across enterprise fleets — MDM profiles for Bedrock / Vertex / Foundry / third-party and self-hosted LLM gateways, org-plugin distribution, per-host diagnostics.

**Why cowork-mdm** — three-paragraph rewrite:
1. Third-party Anthropic-compatible LLM support. Providers picked on cost / data residency / compliance / model preference. Examples span hyperscalers (Bedrock / Vertex / Foundry), self-hosted (vLLM / SGLang behind an Anthropic-compatible shim), and third-party services (DeepSeek, Zhipu GLM, MiniMax, Mistral's API, and similar).
2. 51-key MDM config complexity (with "8 of 51" as credibility proof, not the lead).
3. Hybrid delivery truth — mobileconfig for config, Script payload for plugins/skills. Links to `docs/research/skills-plugins-mdm.md`.

**Quick start** — 6-command happy path (`show-template` → `$EDITOR` → `new --from` → `lint` → `validate` → MDM push).

**New "Enterprise deployment cookbook" section** — pulls `docs/deployment-cn.md` into its proper main-narrative billing with an 8-section preview.

**Command reference** — reorganized by **intent** (Author / Inspect schema / Apply & verify / Manage plugins), not by subcommand name.

**Claude Code plugin section** — compressed from ~50 lines + two tables to ~8 lines + pointer to `specs/claude-plugin.md`.

**`README.zh.md`** — new 109-line Chinese-language mirror, same provider-neutral narrative arc. Idiomatic, not translation-style. Language toggle at top of both files.

**`docs/deployment-cn.md`** — H1 reframed ("Chinese LLM providers" → "gateway-mode cookbook"), intro rewritten with Mistral and self-hosted examples, Section 1/2/4 wording opened up to "several gateway providers" / "e.g. DeepSeek, Zhipu GLM, MiniMax, Mistral, self-hosted gateway".

## Sparring trail

- **Round 1** (plan): 4 directives — keep "8 of 51" as credibility not lead; broaden tagline beyond CN; compress plugin section preserving install snippet; drop Cowork-as-noun. Addressed, applied.
- **Round 2** (initial post-user-feedback plan): CONCERNS on "open-source LLM gateways" being inaccurate for hosted APIs → switched to "third-party / self-hosted LLM gateways" (aligned with `gateway.yaml` wording). CONCERNS on DeepSeek/GLM/MiniMax listing still implying CN → added Mistral + reordered to hyperscalers-first.
- **Round 3** (final after reframe): 2 non-blocking wording polish (zh idiom + cookbook body residuals) — both applied.

## Deferred to follow-up (flagged for tracking)

Not addressed in this PR to keep scope focused:

- **Template name `enterprise-cn-full`**: literal CLI identifier referenced in tests + plugin skill doc + cookbook. Rename needs 6+ file coordinated update.
- **Cookbook filename `docs/deployment-cn.md`**: keeps backlinks stable. Rename or alias can ship alongside the template rename.

Both are identifiers / file paths, not narrative — users reading the docs now see the reframed content regardless.

## Non-goals

- **No new content.** Only restructures, reframes, and translates what exists. All linked docs already exist.
- **No product scope changes.** The tool does the same things.
- **No CN-exclusive framing.** Global deployments stay explicitly covered.

## Test plan

- [x] `grep -i "chinese\|china\|domestic" README.md README.zh.md docs/deployment-cn.md` → no matches.
- [x] All markdown links point to real files on `main`.
- [x] Language toggle works both directions.
- [x] Three rounds of `/codex:rescue` sparring: plan + post-feedback-plan + final → APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)